### PR TITLE
Refactor MirrorUsagePoint and MirrorMeterReading sending for CSIP-AUS

### DIFF
--- a/src/coordinator/helpers/derSample.test.ts
+++ b/src/coordinator/helpers/derSample.test.ts
@@ -36,11 +36,11 @@ describe('generateDerSample', () => {
             date: now,
             realPower: {
                 type: 'noPhase',
-                value: 6990,
+                net: 6990,
             },
             reactivePower: {
                 type: 'noPhase',
-                value: -25,
+                net: -25,
             },
             voltage: {
                 type: 'perPhase',
@@ -85,11 +85,11 @@ describe('generateDerSample', () => {
             date: now,
             realPower: {
                 type: 'noPhase',
-                value: 13980,
+                net: 13980,
             },
             reactivePower: {
                 type: 'noPhase',
-                value: -50,
+                net: -50,
             },
             voltage: {
                 type: 'perPhase',

--- a/src/coordinator/helpers/derSample.ts
+++ b/src/coordinator/helpers/derSample.ts
@@ -30,13 +30,13 @@ export function generateDerSample({
         date: new Date(),
         realPower: {
             type: 'noPhase',
-            value: sumNumbersArray(
+            net: sumNumbersArray(
                 invertersData.map((data) => data.inverter.realPower),
             ),
         },
         reactivePower: {
             type: 'noPhase',
-            value: sumNumbersArray(
+            net: sumNumbersArray(
                 invertersData.map((data) => data.inverter.reactivePower),
             ),
         },

--- a/src/coordinator/helpers/inverterData.test.ts
+++ b/src/coordinator/helpers/inverterData.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { getConnectStatusFromPVConn } from './inverterData.js';
+import { getGenConnectStatusFromPVConn } from './inverterData.js';
 import { PVConn } from '../../sunspec/models/status.js';
 import { ConnectStatus } from '../../sep2/models/connectStatus.js';
 
-describe('getConnectStatusFromPVConn', () => {
+describe('getGenConnectStatusFromPVConn', () => {
     it('should return value if inverter is disconnected', () => {
-        const result = getConnectStatusFromPVConn(0 as PVConn);
+        const result = getGenConnectStatusFromPVConn(0 as PVConn);
 
         expect(result).toEqual(0 as ConnectStatus);
     });
 
-    it('should return value if inverter is connected, available, operating', () => {
-        const result = getConnectStatusFromPVConn(
-            PVConn.AVAILABLE | PVConn.CONNECTED | PVConn.OPERATING,
+    it('should return correct value if inverter is connected, available, operating', () => {
+        const result = getGenConnectStatusFromPVConn(
+            PVConn.CONNECTED | PVConn.AVAILABLE | PVConn.OPERATING,
         );
 
         expect(result).toEqual(
@@ -20,5 +20,20 @@ describe('getConnectStatusFromPVConn', () => {
                 ConnectStatus.Connected |
                 ConnectStatus.Operating,
         );
+    });
+
+    it('should return correct value if inverter is available, operating (not connected)', () => {
+        const result = getGenConnectStatusFromPVConn(
+            PVConn.AVAILABLE | PVConn.OPERATING,
+        );
+
+        // this is subject to debate
+        // the following is the advise from SAPN
+        // The current SAPN interpretation is that operating would mean operating as expected, in which case it could only be considered operating if it is connected and available. Therefore a connectstatus of 6 would not be possible in our implementation.
+        // Our interpretation would be as follows:
+        // Bit 0: Connected = AC connected
+        // Bit 1: Available = AC connected and available to react to controls to increase or reduce energy dispatch
+        // Bit 2: Operating = Connected, available, and currently observing a powerflow or carrying out a control to increase or reduce energy dispatch (eg. Includes opmodgenlimw = 0 but excludes opmodenergize = false)
+        expect(result).toEqual(0);
     });
 });

--- a/src/coordinator/helpers/inverterData.ts
+++ b/src/coordinator/helpers/inverterData.ts
@@ -101,27 +101,35 @@ export function generateInverterDataStatus({
         )
             ? OperationalModeStatus.OperationalMode
             : OperationalModeStatus.Off,
-        genConnectStatus: getConnectStatusFromPVConn(statusMetrics.PVConn),
+        genConnectStatus: getGenConnectStatusFromPVConn(statusMetrics.PVConn),
     };
 }
 
-export function getConnectStatusFromPVConn(pvConn: PVConn): ConnectStatus {
+export function getGenConnectStatusFromPVConn(pvConn: PVConn): ConnectStatus {
     let result: ConnectStatus = 0 as ConnectStatus;
 
     if (enumHasValue(pvConn, PVConn.CONNECTED)) {
         result += ConnectStatus.Connected;
+    } else {
+        return result;
     }
 
     if (enumHasValue(pvConn, PVConn.AVAILABLE)) {
         result += ConnectStatus.Available;
+    } else {
+        return result;
     }
 
     if (enumHasValue(pvConn, PVConn.OPERATING)) {
         result += ConnectStatus.Operating;
+    } else {
+        return result;
     }
 
     if (enumHasValue(pvConn, PVConn.TEST)) {
         result += ConnectStatus.Test;
+    } else {
+        return result;
     }
 
     return result;

--- a/src/coordinator/helpers/sampleBase.ts
+++ b/src/coordinator/helpers/sampleBase.ts
@@ -2,14 +2,28 @@ export type SampleBase = {
     date: Date;
 };
 
-export function getSamplesIntervalSeconds<T extends SampleBase>(samples: T[]) {
-    // assume samples are in order from oldest to newest
-    if (samples.length < 2) {
-        return 0;
+export type SampleTimePeriod = {
+    start: Date;
+    end: Date;
+    durationSeconds: number;
+};
+
+export function getSampleTimePeriod<T extends SampleBase>(
+    samples: T[],
+): SampleTimePeriod {
+    if (samples.length === 0) {
+        throw new Error('No samples to calculate time period');
     }
 
-    const oldest = samples.at(0)!.date;
-    const newest = samples.at(-1)!.date;
+    const start = samples.at(0)!.date;
+    const end = samples.at(-1)!.date;
+    const durationSeconds = Math.round(
+        (end.getTime() - start.getTime()) / 1000,
+    );
 
-    return Math.round((newest.getTime() - oldest.getTime()) / 1000);
+    return {
+        start,
+        end,
+        durationSeconds,
+    };
 }

--- a/src/helpers/influxdb.ts
+++ b/src/helpers/influxdb.ts
@@ -27,7 +27,7 @@ export function writeSiteSamplePoints(siteSample: SiteSample) {
                     .timestamp(siteSample.date)
                     .tag('type', 'site')
                     .tag('phase', 'none')
-                    .floatField('realPower', siteSample.realPower.value),
+                    .floatField('realPower', siteSample.realPower.net),
             );
             break;
         }
@@ -79,7 +79,7 @@ export function writeSiteSamplePoints(siteSample: SiteSample) {
                     .tag('phase', 'none')
                     .floatField(
                         'reactivePower',
-                        siteSample.reactivePower.value,
+                        siteSample.reactivePower.net,
                     ),
             );
             break;
@@ -183,7 +183,7 @@ export function writeDerSamplePoints(derSample: DerSample) {
                     .timestamp(derSample.date)
                     .tag('type', 'der')
                     .tag('phase', 'none')
-                    .floatField('realPower', derSample.realPower.value),
+                    .floatField('realPower', derSample.realPower.net),
             );
             break;
         }
@@ -233,7 +233,7 @@ export function writeDerSamplePoints(derSample: DerSample) {
                     .timestamp(derSample.date)
                     .tag('type', 'der')
                     .tag('phase', 'none')
-                    .floatField('reactivePower', derSample.reactivePower.value),
+                    .floatField('reactivePower', derSample.reactivePower.net),
             );
             break;
         }

--- a/src/helpers/influxdb.ts
+++ b/src/helpers/influxdb.ts
@@ -77,10 +77,7 @@ export function writeSiteSamplePoints(siteSample: SiteSample) {
                     .timestamp(siteSample.date)
                     .tag('type', 'site')
                     .tag('phase', 'none')
-                    .floatField(
-                        'reactivePower',
-                        siteSample.reactivePower.net,
-                    ),
+                    .floatField('reactivePower', siteSample.reactivePower.net),
             );
             break;
         }

--- a/src/helpers/measurement.test.ts
+++ b/src/helpers/measurement.test.ts
@@ -43,8 +43,8 @@ describe('assertPerPhaseOrNoPhaseMeasurementArray', () => {
 
     it('should return noPhase when only noPhase measurements are present', () => {
         const noPhaseMeasurements: NoPhaseMeasurement[] = [
-            { type: 'noPhase', value: 100 },
-            { type: 'noPhase', value: 200 },
+            { type: 'noPhase', net: 100 },
+            { type: 'noPhase', net: 200 },
         ];
 
         const result =
@@ -67,7 +67,7 @@ describe('assertPerPhaseOrNoPhaseMeasurementArray', () => {
                 phaseC: 30,
                 net: 60,
             },
-            { type: 'noPhase', value: 100 },
+            { type: 'noPhase', net: 100 },
             {
                 type: 'perPhaseNet',
                 phaseA: 40,
@@ -116,7 +116,7 @@ describe('getTotalFromPerPhaseOrNoPhaseMeasurement', () => {
     it('should return the value from noPhase measurement', () => {
         const noPhaseMeasurement: NoPhaseMeasurement = {
             type: 'noPhase',
-            value: 100,
+            net: 100,
         };
 
         const result =
@@ -159,18 +159,18 @@ describe('getAvgMaxMinOfPerPhaseOrNoPhaseMeasurements', () => {
             {
                 type: 'noPhase',
                 measurements: [
-                    { type: 'noPhase', value: 100 },
-                    { type: 'noPhase', value: 200 },
-                    { type: 'noPhase', value: 300 },
+                    { type: 'noPhase', net: 100 },
+                    { type: 'noPhase', net: 200 },
+                    { type: 'noPhase', net: 300 },
                 ],
             };
 
         const result =
             getAvgMaxMinOfPerPhaseNetOrNoPhaseMeasurements(noPhaseMeasurements);
         expect(result).toEqual({
-            average: { type: 'noPhase', value: 200 }, // (100 + 200 + 300) / 3 = 200
-            maximum: { type: 'noPhase', value: 300 },
-            minimum: { type: 'noPhase', value: 100 },
+            average: { type: 'noPhase', net: 200 }, // (100 + 200 + 300) / 3 = 200
+            maximum: { type: 'noPhase', net: 300 },
+            minimum: { type: 'noPhase', net: 100 },
         });
     });
 

--- a/src/helpers/measurement.ts
+++ b/src/helpers/measurement.ts
@@ -31,7 +31,7 @@ export type PerPhaseNetMeasurement = z.infer<
 
 export const noPhaseMeasurementSchema = z.object({
     type: z.literal('noPhase'),
-    value: z.number(),
+    net: z.number(),
 });
 
 export type NoPhaseMeasurement = z.infer<typeof noPhaseMeasurementSchema>;
@@ -82,7 +82,7 @@ export function getTotalFromPerPhaseNetOrNoPhaseMeasurement(
 ) {
     switch (measurement.type) {
         case 'noPhase':
-            return measurement.value;
+            return measurement.net;
         case 'perPhaseNet':
             return measurement.net;
     }
@@ -202,20 +202,20 @@ export function getAvgMaxMinOfPerPhaseNetOrNoPhaseMeasurements(
 ): AvgMaxMin<PerPhaseNetMeasurement | NoPhaseMeasurement> {
     switch (array.type) {
         case 'noPhase': {
-            const values = array.measurements.map((m) => m.value);
+            const values = array.measurements.map((m) => m.net);
 
             return {
                 average: {
                     type: 'noPhase',
-                    value: averageNumbersArray(values),
+                    net: averageNumbersArray(values),
                 },
                 maximum: {
                     type: 'noPhase',
-                    value: Math.max(...values),
+                    net: Math.max(...values),
                 },
                 minimum: {
                     type: 'noPhase',
-                    value: Math.min(...values),
+                    net: Math.min(...values),
                 },
             };
         }

--- a/src/helpers/number.test.ts
+++ b/src/helpers/number.test.ts
@@ -147,6 +147,18 @@ describe('convertNumberToBaseAndPow10Exponent', () => {
         const result = convertNumberToBaseAndPow10Exponent(0.0);
         expect(result).toEqual({ base: 0, pow10: 0 });
     });
+
+    it('should convert NaN', () => {
+        const result = convertNumberToBaseAndPow10Exponent(Number.NaN);
+        expect(result).toEqual({ base: 0, pow10: 0 });
+    });
+
+    it('should convert Infinity', () => {
+        const result = convertNumberToBaseAndPow10Exponent(
+            Number.POSITIVE_INFINITY,
+        );
+        expect(result).toEqual({ base: 0, pow10: 0 });
+    });
 });
 
 describe('sumBigIntArray', () => {

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -74,6 +74,10 @@ export function convertNumberToBaseAndPow10Exponent(number: number): {
     base: number;
     pow10: number;
 } {
+    if (Number.isNaN(number) || !Number.isFinite(number)) {
+        return { base: 0, pow10: 0 };
+    }
+
     let decimal = new Decimal(number);
 
     // Special case for 0

--- a/src/meters/sunspec/index.ts
+++ b/src/meters/sunspec/index.ts
@@ -65,7 +65,7 @@ export function generateSiteSample({
                   phaseC: meterMetrics.WphC,
                   net: meterMetrics.W,
               }
-            : { type: 'noPhase', value: meterMetrics.W },
+            : { type: 'noPhase', net: meterMetrics.W },
         reactivePower: meterMetrics.VARphA
             ? {
                   type: 'perPhaseNet',
@@ -76,7 +76,7 @@ export function generateSiteSample({
               }
             : {
                   type: 'noPhase',
-                  value: assertNonNull(meterMetrics.VAR),
+                  net: assertNonNull(meterMetrics.VAR),
               },
         voltage: {
             type: 'perPhase',

--- a/src/sep2/client.test.ts
+++ b/src/sep2/client.test.ts
@@ -39,22 +39,51 @@ describe('generateUsagePointMrid', () => {
 
 describe('generateMeterReadingMrid', () => {
     it('should generate meter reading MRID with PEN', () => {
-        const result = sep2Client.generateMeterReadingMrid(
-            'Average Real Power (W)',
-        );
+        const result = sep2Client.generateMeterReadingMrid({
+            roleFlags:
+                RoleFlagsType.isMirror |
+                RoleFlagsType.isDER |
+                RoleFlagsType.isSubmeter,
+            description: 'Average Real Power (W)',
+        });
 
         expect(result).toContain('00012345');
     });
 
-    it('should generate meter reading MRID based on hash', () => {
-        const result = sep2Client.generateMeterReadingMrid(
-            'Average Real Power (W)',
-        );
-        const result2 = sep2Client.generateMeterReadingMrid(
-            'Minimum Real Power (W)',
-        );
+    it('should generate meter reading MRID based on roleFlags', () => {
+        const result = sep2Client.generateMeterReadingMrid({
+            roleFlags:
+                RoleFlagsType.isMirror |
+                RoleFlagsType.isDER |
+                RoleFlagsType.isSubmeter,
+            description: 'Average Real Power (W)',
+        });
+        const result2 = sep2Client.generateMeterReadingMrid({
+            roleFlags:
+                RoleFlagsType.isMirror |
+                RoleFlagsType.isPremisesAggregationPoint,
+            description: 'Average Real Power (W)',
+        });
 
-        expect(result).toBe('FC5ACDBAD6E6F0362CC0C1B800012345');
+        expect(result).toBe('FC5ACDBAD6E6F0362CC0C14900012345');
+        expect(result).not.toBe(result2);
+    });
+
+    it('should generate meter reading MRID based on description hash', () => {
+        const result = sep2Client.generateMeterReadingMrid({
+            roleFlags:
+                RoleFlagsType.isMirror |
+                RoleFlagsType.isPremisesAggregationPoint,
+            description: 'Average Real Power (W)',
+        });
+        const result2 = sep2Client.generateMeterReadingMrid({
+            roleFlags:
+                RoleFlagsType.isMirror |
+                RoleFlagsType.isPremisesAggregationPoint,
+            description: 'Minimum Real Power (W)',
+        });
+
+        expect(result).toBe('FC5ACDBAD6E6F0362CC0C10300012345');
         expect(result).not.toBe(result2);
     });
 });

--- a/src/sep2/client.test.ts
+++ b/src/sep2/client.test.ts
@@ -37,10 +37,24 @@ describe('generateUsagePointMrid', () => {
     });
 });
 
-it('should generate meter reading MRID', () => {
-    const result = sep2Client.generateMeterReadingMrid();
-    const result2 = sep2Client.generateMeterReadingMrid();
+describe('generateMeterReadingMrid', () => {
+    it('should generate meter reading MRID with PEN', () => {
+        const result = sep2Client.generateMeterReadingMrid(
+            'Average Real Power (W)',
+        );
 
-    expect(result).toContain('00012345');
-    expect(result).not.toBe(result2);
+        expect(result).toContain('00012345');
+    });
+
+    it('should generate meter reading MRID based on hash', () => {
+        const result = sep2Client.generateMeterReadingMrid(
+            'Average Real Power (W)',
+        );
+        const result2 = sep2Client.generateMeterReadingMrid(
+            'Minimum Real Power (W)',
+        );
+
+        expect(result).toBe('FC5ACDBAD6E6F0362CC0C1B800012345');
+        expect(result).not.toBe(result2);
+    });
 });

--- a/src/sep2/client.ts
+++ b/src/sep2/client.ts
@@ -156,8 +156,14 @@ response data: ${JSON.stringify(error.response?.data, null, 2)}`,
     // From the SEP2 Client Handbook
     // The mRID of each MeterReading needs to be unique for that EndDevice
     // hash the description to generate a consistent mRID for the "type" of MeterReadingMrid
-    generateMeterReadingMrid(description: string) {
-        return `${createHash('sha256').update(description).digest('hex').substring(0, 24).toUpperCase()}${this.pen}`;
+    generateMeterReadingMrid({
+        description,
+        roleFlags,
+    }: {
+        description: string;
+        roleFlags: RoleFlagsType;
+    }) {
+        return `${createHash('sha256').update(description).digest('hex').substring(0, 22).toUpperCase()}${numberToHex(roleFlags).padStart(2, '0')}${this.pen}`;
     }
 }
 

--- a/src/sep2/client.ts
+++ b/src/sep2/client.ts
@@ -10,19 +10,19 @@ import {
 import type { Config } from '../helpers/config.js';
 import type { RoleFlagsType } from './models/roleFlagsType.js';
 import { numberToHex } from '../helpers/number.js';
-import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { DeviceCapabilityHelper } from './helpers/deviceCapability.js';
 import axiosRetry from 'axios-retry';
 
 const USER_AGENT = 'open-dynamic-export';
 
 export class SEP2Client {
-    private host: string;
-    private dcapUri: string;
-    private pen: string;
-    public lfdi: string;
-    public sfdi: string;
-    private axiosInstance: AxiosInstance;
+    private readonly host: string;
+    private readonly dcapUri: string;
+    public readonly pen: string;
+    public readonly lfdi: string;
+    public readonly sfdi: string;
+    private readonly axiosInstance: AxiosInstance;
 
     constructor({
         sep2Config,
@@ -155,8 +155,9 @@ response data: ${JSON.stringify(error.response?.data, null, 2)}`,
 
     // From the SEP2 Client Handbook
     // The mRID of each MeterReading needs to be unique for that EndDevice
-    generateMeterReadingMrid() {
-        return `${randomUUID().replace(/-/g, '').substring(0, 24)}${this.pen}`;
+    // hash the description to generate a consistent mRID for the "type" of MeterReadingMrid
+    generateMeterReadingMrid(description: string) {
+        return `${createHash('sha256').update(description).digest('hex').substring(0, 24).toUpperCase()}${this.pen}`;
     }
 }
 

--- a/src/sep2/helpers/mirrorUsagePointBase.ts
+++ b/src/sep2/helpers/mirrorUsagePointBase.ts
@@ -13,23 +13,40 @@ import { ServiceKind } from '../models/serviceKind.js';
 import { objectToXml } from './xml.js';
 import type { Logger } from 'pino';
 import { UsagePointBaseStatus } from '../models/usagePointBase.js';
-import { convertNumberToBaseAndPow10Exponent } from '../../helpers/number.js';
-import { CommodityType } from '../models/commodityType.js';
-import type { DataQualifierType } from '../models/dataQualifierType.js';
-import type { FlowDirectionType } from '../models/flowDirectionType.js';
-import { KindType } from '../models/kindType.js';
-import type { PhaseCode } from '../models/phaseCode.js';
-import { QualityFlags } from '../models/qualityFlags.js';
-import type { UomType } from '../models/uomType.js';
+import { numberWithPow10 } from '../../helpers/number.js';
+import type { SampleBase } from '../../coordinator/helpers/sampleBase.js';
+import { getSampleTimePeriod } from '../../coordinator/helpers/sampleBase.js';
+import { objectEntriesWithType } from '../../helpers/object.js';
 
-export abstract class MirrorUsagePointHelperBase<Sample, Reading> {
+export type MirrorMeterReadingDefinitions = Required<
+    Pick<MirrorMeterReading, 'description'> & {
+        ReadingType: Required<
+            Pick<
+                NonNullable<MirrorMeterReading['ReadingType']>,
+                | 'commodity'
+                | 'kind'
+                | 'dataQualifier'
+                | 'flowDirection'
+                | 'phase'
+                | 'powerOfTenMultiplier'
+                | 'uom'
+            >
+        >;
+    }
+>;
+
+export abstract class MirrorUsagePointHelperBase<
+    Sample extends SampleBase,
+    Reading,
+    MirrorMeterReadingKeys extends string,
+> {
     protected client: SEP2Client;
     protected mirrorUsagePointListHref: string | null = null;
     protected mirrorUsagePoint: MirrorUsagePoint | null = null;
     protected samples: Sample[] = [];
     protected abstract description: string;
     protected abstract roleFlags: RoleFlagsType;
-    protected postTimer: NodeJS.Timeout | null = null;
+    protected mirrorMeterReadingPostTimer: NodeJS.Timeout | null = null;
     protected abstract logger: Logger;
 
     constructor({ client }: { client: SEP2Client }) {
@@ -37,29 +54,16 @@ export abstract class MirrorUsagePointHelperBase<Sample, Reading> {
     }
 
     public async updateMirrorUsagePointList({
-        mirrorUsagePoints,
         mirrorUsagePointListHref,
     }: {
-        mirrorUsagePoints: MirrorUsagePoint[];
         mirrorUsagePointListHref: string;
     }) {
         this.mirrorUsagePointListHref = mirrorUsagePointListHref;
 
-        // use existing mirrorUsagePoint if it has already been created before
-        const existingMirrorUsagePoint = mirrorUsagePoints.find(
-            (point) =>
-                point.deviceLFDI === this.client.lfdi &&
-                point.status === UsagePointBaseStatus.On &&
-                point.roleFlags === this.roleFlags,
-        );
-
-        if (existingMirrorUsagePoint) {
-            this.mirrorUsagePoint = existingMirrorUsagePoint;
-            this.startPosting();
-            return;
-        }
-
-        // if does not exist, create new mirrorUsagePoint
+        // set up MirrorUsagePoint with MirrorMeterReading definitions
+        // MirrorUsasgePoint must require at least one MirrorMeterReading definition
+        // we define the MirrorMeterReading.ReadingType defintion upfront because they won't change
+        // we also want to set this up early so we know the correct postRate (set by the server)
         this.mirrorUsagePoint = await this.postMirrorUsagePoint({
             mirrorUsagePoint: {
                 mRID: this.client.generateUsagePointMrid(this.roleFlags),
@@ -68,16 +72,20 @@ export abstract class MirrorUsagePointHelperBase<Sample, Reading> {
                 serviceCategoryKind: ServiceKind.Electricity,
                 status: UsagePointBaseStatus.On,
                 deviceLFDI: this.client.lfdi,
+                mirrorMeterReading:
+                    this.getMirrorMeterReadingsWithReadingType(),
             },
         });
 
-        this.startPosting();
+        this.startMirrorMeterReadingsPost();
     }
 
-    protected startPosting() {
-        if (this.postTimer) return;
+    protected startMirrorMeterReadingsPost() {
+        if (this.mirrorMeterReadingPostTimer) {
+            return;
+        }
 
-        void this.post();
+        void this.mirrorMeterReadingsPost();
     }
 
     public addSample(sample: Sample) {
@@ -86,150 +94,115 @@ export abstract class MirrorUsagePointHelperBase<Sample, Reading> {
 
     protected abstract getReadingFromSamples(samples: Sample[]): Reading;
 
-    public post() {
-        const nextUpdateMilliseconds = getMillisecondsToNextHourMinutesInterval(
-            (this.mirrorUsagePoint?.postRate ??
-                defaultPollPushRates.mirrorUsagePointPush) / 60,
-        );
+    protected abstract getReadingMrid(key: MirrorMeterReadingKeys): string;
 
-        this.postTimer = setTimeout(() => {
-            void this.post();
-        }, nextUpdateMilliseconds);
+    protected abstract getReadingDefintions(): Record<
+        MirrorMeterReadingKeys,
+        MirrorMeterReadingDefinitions
+    >;
+
+    protected abstract getReadingValues({
+        reading,
+    }: {
+        reading: Reading;
+    }): Record<MirrorMeterReadingKeys, number | null>;
+
+    private getPostRate() {
+        return (
+            (this.mirrorUsagePoint?.postRate ??
+                defaultPollPushRates.mirrorUsagePointPush) / 60
+        );
+    }
+
+    public async mirrorMeterReadingsPost() {
+        // this is a function because we want to evaluate `this.mirrorUsagePoint?.postRate` every time
+        // the mirrorUsagePoint may be updated after we post to it so we want to get the latest postRate
+        const getNextUpdateMilliseconds = () =>
+            getMillisecondsToNextHourMinutesInterval(this.getPostRate());
 
         const samples = this.getSamplesAndClear();
 
+        // we only want to post if we have samples
+        // without samples, the reading values min/max will be infinity
+        // we won't know what reading types we have
         if (samples.length > 0) {
             const reading = this.getReadingFromSamples(samples);
+            const sampleTimePeriod = getSampleTimePeriod(samples);
             const lastUpdateTime = new Date();
             const nextUpdateTime = new Date(
-                Date.now() + nextUpdateMilliseconds,
+                Date.now() + getNextUpdateMilliseconds(),
+            );
+            const mirrorMeterReadings = this.getReadingValues({
+                reading,
+            });
+
+            const mirrorMeterReadingDefinitions = this.getReadingDefintions();
+
+            await Promise.all(
+                objectEntriesWithType(mirrorMeterReadings).map(
+                    async ([key, value]) => {
+                        // don't post null reading values
+                        if (value === null) {
+                            return;
+                        }
+
+                        return await this.postMirrorMeterReading({
+                            mirrorMeterReading: {
+                                mRID: this.getReadingMrid(key),
+                                lastUpdateTime,
+                                nextUpdateTime,
+                                Reading: {
+                                    // the value must not contain a decimal point
+                                    // shift the base value by the power of 10 multiplier
+                                    value: Math.round(
+                                        numberWithPow10(
+                                            value,
+                                            -mirrorMeterReadingDefinitions[key]
+                                                .ReadingType
+                                                .powerOfTenMultiplier,
+                                        ),
+                                    ),
+
+                                    timePeriod: {
+                                        start: sampleTimePeriod.start,
+                                        duration:
+                                            sampleTimePeriod.durationSeconds,
+                                    },
+                                },
+                            },
+                        });
+                    },
+                ),
             );
 
-            try {
-                this.postRealPower({
-                    reading,
-                    lastUpdateTime,
-                    nextUpdateTime,
-                });
-
-                this.postReactivePower({
-                    reading,
-                    lastUpdateTime,
-                    nextUpdateTime,
-                });
-
-                this.postVoltage({
-                    reading,
-                    lastUpdateTime,
-                    nextUpdateTime,
-                });
-
-                this.postFrequency({
-                    reading,
-                    lastUpdateTime,
-                    nextUpdateTime,
-                });
-            } catch (error) {
-                this.logger.error(
-                    { error },
-                    'Error posting one of MirrorMeterReading during scheduled pushing',
-                );
-            }
+            this.logger.debug('Sent MirrorMeterReadings');
         }
+
+        this.mirrorMeterReadingPostTimer = setTimeout(() => {
+            void this.mirrorMeterReadingsPost();
+        }, getNextUpdateMilliseconds());
     }
 
-    protected abstract postRealPower({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: Reading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }): void;
-
-    protected abstract postReactivePower({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: Reading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }): void;
-
-    protected abstract postVoltage({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: Reading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }): void;
-
-    protected abstract postFrequency({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: Reading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }): void;
+    private getMirrorMeterReadingsWithReadingType(): Omit<
+        MirrorMeterReading,
+        'Reading'
+    >[] {
+        return objectEntriesWithType(this.getReadingDefintions()).map(
+            ([key, readingDefinition]): Omit<MirrorMeterReading, 'Reading'> => {
+                return {
+                    mRID: this.getReadingMrid(key),
+                    description: readingDefinition.description,
+                    ReadingType: readingDefinition.ReadingType,
+                };
+            },
+        );
+    }
 
     protected getSamplesAndClear(): Sample[] {
         const cache = this.samples;
         this.samples = [];
         return cache;
     }
-
-    protected sendMirrorMeterReading = ({
-        phase,
-        flowDirection,
-        dataQualifier,
-        description,
-        value,
-        uom,
-        lastUpdateTime,
-        nextUpdateTime,
-        intervalLength,
-    }: {
-        phase: PhaseCode;
-        flowDirection: FlowDirectionType;
-        dataQualifier: DataQualifierType;
-        description: string;
-        value: number;
-        uom: UomType;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-        intervalLength: number;
-    }) => {
-        const exponentValue = convertNumberToBaseAndPow10Exponent(value);
-
-        void this.postMirrorMeterReading({
-            mirrorMeterReading: {
-                mRID: this.client.generateMeterReadingMrid(),
-                description,
-                lastUpdateTime,
-                nextUpdateTime,
-                Reading: {
-                    value: exponentValue.base,
-                    qualityFlags: QualityFlags.Valid,
-                },
-                ReadingType: {
-                    commodity: CommodityType.ElectricitySecondaryMeteredValue,
-                    kind: KindType.Power,
-                    dataQualifier,
-                    flowDirection,
-                    intervalLength,
-                    phase,
-                    powerOfTenMultiplier: exponentValue.pow10,
-                    uom,
-                },
-            },
-        });
-    };
 
     private async postMirrorUsagePoint({
         mirrorUsagePoint,
@@ -271,6 +244,11 @@ export abstract class MirrorUsagePointHelperBase<Sample, Reading> {
         const data = generateMirrorMeterReadingResponse(mirrorMeterReading);
         const xml = objectToXml(data);
 
-        await this.client.post(this.mirrorUsagePoint.href, xml);
+        const response = await this.client.post(
+            this.mirrorUsagePoint.href,
+            xml,
+        );
+
+        return response;
     }
 }

--- a/src/sep2/helpers/mirrorUsagePointDer.ts
+++ b/src/sep2/helpers/mirrorUsagePointDer.ts
@@ -1,5 +1,4 @@
 import { RoleFlagsType } from '../models/roleFlagsType.js';
-import { getSamplesIntervalSeconds } from '../../coordinator/helpers/sampleBase.js';
 import type {
     NoPhaseMeasurement,
     PerPhaseNetMeasurement,
@@ -16,21 +15,463 @@ import { DataQualifierType } from '../models/dataQualifierType.js';
 import { FlowDirectionType } from '../models/flowDirectionType.js';
 import { PhaseCode } from '../models/phaseCode.js';
 import { UomType } from '../models/uomType.js';
+import type { MirrorMeterReadingDefinitions } from './mirrorUsagePointBase.js';
 import { MirrorUsagePointHelperBase } from './mirrorUsagePointBase.js';
 import { logger as pinoLogger } from '../../helpers/logger.js';
 import type { DerSample } from '../../coordinator/helpers/derSample.js';
+import { CommodityType } from '../models/commodityType.js';
+import { KindType } from '../models/kindType.js';
+import type { SEP2Client } from '../client.js';
+import { objectEntriesWithType } from '../../helpers/object.js';
 
 type DerReading = {
-    intervalSeconds: number;
     realPower: AvgMaxMin<PerPhaseNetMeasurement | NoPhaseMeasurement>;
     reactivePower: AvgMaxMin<PerPhaseNetMeasurement | NoPhaseMeasurement>;
     voltage: AvgMaxMin<PerPhaseMeasurement> | null;
     frequency: AvgMaxMin<number> | null;
 };
 
+const mirrorMeterReadingDefinitions = {
+    realPowerNetAverage: {
+        description: 'Average Real Power (W) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseAAverage: {
+        description: 'Average Real Power (W) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseBAverage: {
+        description: 'Average Real Power (W) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseCAverage: {
+        description: 'Average Real Power (W) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerNetMaximum: {
+        description: 'Maximum Real Power (W) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseAMaximum: {
+        description: 'Maximum Real Power (W) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseBMaximum: {
+        description: 'Maximum Real Power (W) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseCMaximum: {
+        description: 'Maximum Real Power (W) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerNetMinimum: {
+        description: 'Minimum Real Power (W) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseAMinimum: {
+        description: 'Minimum Real Power (W) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseBMinimum: {
+        description: 'Minimum Real Power (W) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseCMinimum: {
+        description: 'Minimum Real Power (W) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    reactivePowerNetAverage: {
+        description: 'Average Reactive Power (VAR) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseAAverage: {
+        description: 'Average Reactive Power (VAR) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseBAverage: {
+        description: 'Average Reactive Power (VAR) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseCAverage: {
+        description: 'Average Reactive Power (VAR) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerNetMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseAMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseBMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseCMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerNetMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseAMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseBMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseCMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    voltagePhaseAAverage: {
+        description: 'Average Voltage (V) - Phase AN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseBAverage: {
+        description: 'Average Voltage (V) - Phase BN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseCAverage: {
+        description: 'Average Voltage (V) - Phase CN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseAMaximum: {
+        description: 'Maximum Voltage (V) - Phase AN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseBMaximum: {
+        description: 'Maximum Voltage (V) - Phase BN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseCMaximum: {
+        description: 'Maximum Voltage (V) - Phase CN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseAMinimum: {
+        description: 'Minimum Voltage (V) - Phase AN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseBMinimum: {
+        description: 'Minimum Voltage (V) - Phase BN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseCMinimum: {
+        description: 'Minimum Voltage (V) - Phase CN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    frequencyAverage: {
+        description: 'Average Frequency (Hz)',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Hz,
+        },
+    },
+    frequencyMaximum: {
+        description: 'Maximum Frequency (Hz)',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Hz,
+        },
+    },
+    frequencyMinimum: {
+        description: 'Minimum Frequency (Hz)',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Hz,
+        },
+    },
+} satisfies Record<string, MirrorMeterReadingDefinitions>;
+
+type DerMirrorMeterReadingKeys = keyof typeof mirrorMeterReadingDefinitions;
+
 export class MirrorUsagePointDerHelper extends MirrorUsagePointHelperBase<
     DerSample,
-    DerReading
+    DerReading,
+    DerMirrorMeterReadingKeys
 > {
     protected roleFlags =
         RoleFlagsType.isDER | RoleFlagsType.isMirror | RoleFlagsType.isSubmeter;
@@ -38,10 +479,29 @@ export class MirrorUsagePointDerHelper extends MirrorUsagePointHelperBase<
     protected logger = pinoLogger.child({
         module: 'MirrorUsagePointDerHelper',
     });
+    protected mirrorMeterReadingMrids: Record<
+        DerMirrorMeterReadingKeys,
+        string
+    >;
+
+    constructor({ client }: { client: SEP2Client }) {
+        super({ client });
+
+        this.mirrorMeterReadingMrids = Object.fromEntries(
+            objectEntriesWithType(mirrorMeterReadingDefinitions).map(
+                ([key, value]) => [
+                    key,
+                    this.client.generateMeterReadingMrid({
+                        roleFlags: this.roleFlags,
+                        description: value.description,
+                    }),
+                ],
+            ),
+        ) as Record<DerMirrorMeterReadingKeys, string>;
+    }
 
     protected getReadingFromSamples(samples: DerSample[]): DerReading {
         return {
-            intervalSeconds: getSamplesIntervalSeconds(samples),
             realPower: getAvgMaxMinOfPerPhaseNetOrNoPhaseMeasurements(
                 assertPerPhaseNetOrNoPhaseMeasurementArray(
                     samples.map((s) => s.realPower),
@@ -61,486 +521,113 @@ export class MirrorUsagePointDerHelper extends MirrorUsagePointHelperBase<
         };
     }
 
-    protected postRealPower({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: DerReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        const postReading = ({
-            phase,
-            dataQualifier,
-            description,
-            value,
-        }: {
-            phase: PhaseCode;
-            dataQualifier: DataQualifierType;
-            description: string;
-            value: number;
-        }) =>
-            this.sendMirrorMeterReading({
-                phase,
-                flowDirection: FlowDirectionType.Reverse,
-                dataQualifier,
-                description,
-                value,
-                uom: UomType.W,
-                lastUpdateTime,
-                nextUpdateTime,
-                intervalLength: reading.intervalSeconds,
-            });
-
-        switch (reading.realPower.average.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Real Power (W)',
-                    value: reading.realPower.average.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Real Power (W) - Net',
-                    value: reading.realPower.average.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Real Power (W) - Phase A',
-                    value: reading.realPower.average.phaseA,
-                });
-                if (reading.realPower.average.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Real Power (W) - Phase B',
-                        value: reading.realPower.average.phaseB,
-                    });
-                }
-                if (reading.realPower.average.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Real Power (W) - Phase C',
-                        value: reading.realPower.average.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.realPower.maximum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Real Power (W)',
-                    value: reading.realPower.maximum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Real Power (W) - Net',
-                    value: reading.realPower.maximum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Real Power (W) - Phase A',
-                    value: reading.realPower.maximum.phaseA,
-                });
-                if (reading.realPower.maximum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Real Power (W) - Phase B',
-                        value: reading.realPower.maximum.phaseB,
-                    });
-                }
-                if (reading.realPower.maximum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Real Power (W) - Phase C',
-                        value: reading.realPower.maximum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.realPower.minimum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Real Power (W)',
-                    value: reading.realPower.minimum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Real Power (W) - Net',
-                    value: reading.realPower.minimum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Real Power (W) - Phase A',
-                    value: reading.realPower.minimum.phaseA,
-                });
-                if (reading.realPower.minimum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Real Power (W) - Phase B',
-                        value: reading.realPower.minimum.phaseB,
-                    });
-                }
-                if (reading.realPower.minimum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Real Power (W) - Phase C',
-                        value: reading.realPower.minimum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
+    protected override getReadingMrid(key: DerMirrorMeterReadingKeys): string {
+        return this.mirrorMeterReadingMrids[key];
     }
 
-    protected postReactivePower({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: DerReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        const postReading = ({
-            phase,
-            dataQualifier,
-            description,
-            value,
-        }: {
-            phase: PhaseCode;
-            dataQualifier: DataQualifierType;
-            description: string;
-            value: number;
-        }) =>
-            this.sendMirrorMeterReading({
-                phase,
-                flowDirection: FlowDirectionType.Reverse,
-                dataQualifier,
-                description,
-                value,
-                uom: UomType.var,
-                lastUpdateTime,
-                nextUpdateTime,
-                intervalLength: reading.intervalSeconds,
-            });
-
-        switch (reading.reactivePower.average.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Reactive Power (VAR)',
-                    value: reading.reactivePower.average.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Reactive Power (VAR) - Net',
-                    value: reading.reactivePower.average.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Reactive Power (VAR) - Phase A',
-                    value: reading.reactivePower.average.phaseA,
-                });
-                if (reading.reactivePower.average.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Reactive Power (VAR) - Phase B',
-                        value: reading.reactivePower.average.phaseB,
-                    });
-                }
-                if (reading.reactivePower.average.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Reactive Power (VAR) - Phase C',
-                        value: reading.reactivePower.average.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.reactivePower.maximum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Reactive Power (VAR)',
-                    value: reading.reactivePower.maximum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Reactive Power (VAR) - Net',
-                    value: reading.reactivePower.maximum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Reactive Power (VAR) - Phase A',
-                    value: reading.reactivePower.maximum.phaseA,
-                });
-                if (reading.reactivePower.maximum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Reactive Power (VAR) - Phase B',
-                        value: reading.reactivePower.maximum.phaseB,
-                    });
-                }
-                if (reading.reactivePower.maximum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Reactive Power (VAR) - Phase C',
-                        value: reading.reactivePower.maximum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.reactivePower.minimum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Reactive Power (VAR)',
-                    value: reading.reactivePower.minimum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Reactive Power (VAR) - Net',
-                    value: reading.reactivePower.minimum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Reactive Power (VAR) - Phase A',
-                    value: reading.reactivePower.minimum.phaseA,
-                });
-                if (reading.reactivePower.minimum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Reactive Power (VAR) - Phase B',
-                        value: reading.reactivePower.minimum.phaseB,
-                    });
-                }
-                if (reading.reactivePower.minimum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Reactive Power (VAR) - Phase C',
-                        value: reading.reactivePower.minimum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
+    protected override getReadingDefintions(): Record<
+        DerMirrorMeterReadingKeys,
+        MirrorMeterReadingDefinitions
+    > {
+        return mirrorMeterReadingDefinitions;
     }
 
-    protected postVoltage({
+    protected override getReadingValues({
         reading,
-        lastUpdateTime,
-        nextUpdateTime,
     }: {
         reading: DerReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        if (reading.voltage === null) {
-            return;
-        }
-
-        const postReading = ({
-            phase,
-            dataQualifier,
-            description,
-            value,
-        }: {
-            phase: PhaseCode;
-            dataQualifier: DataQualifierType;
-            description: string;
-            value: number;
-        }) =>
-            this.sendMirrorMeterReading({
-                phase,
-                flowDirection: FlowDirectionType.Reverse,
-                dataQualifier,
-                description,
-                value,
-                uom: UomType.Voltage,
-                lastUpdateTime,
-                nextUpdateTime,
-                intervalLength: reading.intervalSeconds,
-            });
-
-        // average
-        postReading({
-            phase: PhaseCode.PhaseAN,
-            dataQualifier: DataQualifierType.Average,
-            description: 'Average Voltage (V) - Phase AN',
-            value: reading.voltage.average.phaseA,
-        });
-        if (reading.voltage.average.phaseB) {
-            postReading({
-                phase: PhaseCode.PhaseBN,
-                dataQualifier: DataQualifierType.Average,
-                description: 'Average Voltage (V) - Phase BN',
-                value: reading.voltage.average.phaseB,
-            });
-        }
-        if (reading.voltage.average.phaseC) {
-            postReading({
-                phase: PhaseCode.PhaseCN,
-                dataQualifier: DataQualifierType.Average,
-                description: 'Average Voltage (V) - Phase CN',
-                value: reading.voltage.average.phaseC,
-            });
-        }
-
-        // maximum
-        postReading({
-            phase: PhaseCode.PhaseAN,
-            dataQualifier: DataQualifierType.Maximum,
-            description: 'Maximum Voltage (V) - Phase AN',
-            value: reading.voltage.maximum.phaseA,
-        });
-        if (reading.voltage.maximum.phaseB) {
-            postReading({
-                phase: PhaseCode.PhaseBN,
-                dataQualifier: DataQualifierType.Maximum,
-                description: 'Maximum Voltage (V) - Phase BN',
-                value: reading.voltage.maximum.phaseB,
-            });
-        }
-        if (reading.voltage.maximum.phaseC) {
-            postReading({
-                phase: PhaseCode.PhaseCN,
-                dataQualifier: DataQualifierType.Maximum,
-                description: 'Maximum Voltage (V) - Phase CN',
-                value: reading.voltage.maximum.phaseC,
-            });
-        }
-
-        // minimum
-        postReading({
-            phase: PhaseCode.PhaseAN,
-            dataQualifier: DataQualifierType.Minimum,
-            description: 'Minimum Voltage (V) - Phase AN',
-            value: reading.voltage.minimum.phaseA,
-        });
-        if (reading.voltage.minimum.phaseB) {
-            postReading({
-                phase: PhaseCode.PhaseBN,
-                dataQualifier: DataQualifierType.Minimum,
-                description: 'Minimum Voltage (V) - Phase BN',
-                value: reading.voltage.minimum.phaseB,
-            });
-        }
-        if (reading.voltage.minimum.phaseC) {
-            postReading({
-                phase: PhaseCode.PhaseCN,
-                dataQualifier: DataQualifierType.Minimum,
-                description: 'Minimum Voltage (V) - Phase CN',
-                value: reading.voltage.minimum.phaseC,
-            });
-        }
-    }
-
-    protected postFrequency({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: DerReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        if (reading.frequency === null) {
-            return;
-        }
-
-        void this.sendMirrorMeterReading({
-            phase: PhaseCode.NotApplicable,
-            flowDirection: FlowDirectionType.Reverse,
-            dataQualifier: DataQualifierType.Average,
-            description: 'Average Frequency (Hz)',
-            value: reading.frequency.average,
-            uom: UomType.Hz,
-            intervalLength: reading.intervalSeconds,
-            lastUpdateTime,
-            nextUpdateTime,
-        });
-
-        void this.sendMirrorMeterReading({
-            phase: PhaseCode.NotApplicable,
-            flowDirection: FlowDirectionType.Reverse,
-            dataQualifier: DataQualifierType.Maximum,
-            description: 'Maximum Frequency (Hz)',
-            value: reading.frequency.maximum,
-            uom: UomType.Hz,
-            intervalLength: reading.intervalSeconds,
-            lastUpdateTime,
-            nextUpdateTime,
-        });
-
-        void this.sendMirrorMeterReading({
-            phase: PhaseCode.NotApplicable,
-            flowDirection: FlowDirectionType.Reverse,
-            dataQualifier: DataQualifierType.Minimum,
-            description: 'Minimum Frequency (Hz)',
-            value: reading.frequency.minimum,
-            uom: UomType.Hz,
-            intervalLength: reading.intervalSeconds,
-            lastUpdateTime,
-            nextUpdateTime,
-        });
+    }): Record<DerMirrorMeterReadingKeys, number | null> {
+        return {
+            realPowerNetAverage: reading.realPower.average.net,
+            realPowerPhaseAAverage:
+                reading.realPower.average.type === 'perPhaseNet'
+                    ? reading.realPower.average.phaseA
+                    : null,
+            realPowerPhaseBAverage:
+                reading.realPower.average.type === 'perPhaseNet'
+                    ? reading.realPower.average.phaseB
+                    : null,
+            realPowerPhaseCAverage:
+                reading.realPower.average.type === 'perPhaseNet'
+                    ? reading.realPower.average.phaseC
+                    : null,
+            realPowerNetMaximum: reading.realPower.maximum.net,
+            realPowerPhaseAMaximum:
+                reading.realPower.maximum.type === 'perPhaseNet'
+                    ? reading.realPower.maximum.phaseA
+                    : null,
+            realPowerPhaseBMaximum:
+                reading.realPower.maximum.type === 'perPhaseNet'
+                    ? reading.realPower.maximum.phaseB
+                    : null,
+            realPowerPhaseCMaximum:
+                reading.realPower.maximum.type === 'perPhaseNet'
+                    ? reading.realPower.maximum.phaseC
+                    : null,
+            realPowerNetMinimum: reading.realPower.minimum.net,
+            realPowerPhaseAMinimum:
+                reading.realPower.minimum.type === 'perPhaseNet'
+                    ? reading.realPower.minimum.phaseA
+                    : null,
+            realPowerPhaseBMinimum:
+                reading.realPower.minimum.type === 'perPhaseNet'
+                    ? reading.realPower.minimum.phaseB
+                    : null,
+            realPowerPhaseCMinimum:
+                reading.realPower.minimum.type === 'perPhaseNet'
+                    ? reading.realPower.minimum.phaseC
+                    : null,
+            reactivePowerNetAverage: reading.reactivePower.average.net,
+            reactivePowerPhaseAAverage:
+                reading.reactivePower.average.type === 'perPhaseNet'
+                    ? reading.reactivePower.average.phaseA
+                    : null,
+            reactivePowerPhaseBAverage:
+                reading.reactivePower.average.type === 'perPhaseNet'
+                    ? reading.reactivePower.average.phaseB
+                    : null,
+            reactivePowerPhaseCAverage:
+                reading.reactivePower.average.type === 'perPhaseNet'
+                    ? reading.reactivePower.average.phaseC
+                    : null,
+            reactivePowerNetMaximum: reading.reactivePower.maximum.net,
+            reactivePowerPhaseAMaximum:
+                reading.reactivePower.maximum.type === 'perPhaseNet'
+                    ? reading.reactivePower.maximum.phaseA
+                    : null,
+            reactivePowerPhaseBMaximum:
+                reading.reactivePower.maximum.type === 'perPhaseNet'
+                    ? reading.reactivePower.maximum.phaseB
+                    : null,
+            reactivePowerPhaseCMaximum:
+                reading.reactivePower.maximum.type === 'perPhaseNet'
+                    ? reading.reactivePower.maximum.phaseC
+                    : null,
+            reactivePowerNetMinimum: reading.reactivePower.minimum.net,
+            reactivePowerPhaseAMinimum:
+                reading.reactivePower.minimum.type === 'perPhaseNet'
+                    ? reading.reactivePower.minimum.phaseA
+                    : null,
+            reactivePowerPhaseBMinimum:
+                reading.reactivePower.minimum.type === 'perPhaseNet'
+                    ? reading.reactivePower.minimum.phaseB
+                    : null,
+            reactivePowerPhaseCMinimum:
+                reading.reactivePower.minimum.type === 'perPhaseNet'
+                    ? reading.reactivePower.minimum.phaseC
+                    : null,
+            voltagePhaseAAverage: reading.voltage?.average.phaseA ?? null,
+            voltagePhaseBAverage: reading.voltage?.average.phaseB ?? null,
+            voltagePhaseCAverage: reading.voltage?.average.phaseC ?? null,
+            voltagePhaseAMaximum: reading.voltage?.maximum.phaseA ?? null,
+            voltagePhaseBMaximum: reading.voltage?.maximum.phaseB ?? null,
+            voltagePhaseCMaximum: reading.voltage?.maximum.phaseC ?? null,
+            voltagePhaseAMinimum: reading.voltage?.minimum.phaseA ?? null,
+            voltagePhaseBMinimum: reading.voltage?.minimum.phaseB ?? null,
+            voltagePhaseCMinimum: reading.voltage?.minimum.phaseC ?? null,
+            frequencyAverage: reading.frequency?.average ?? null,
+            frequencyMaximum: reading.frequency?.maximum ?? null,
+            frequencyMinimum: reading.frequency?.minimum ?? null,
+        };
     }
 }

--- a/src/sep2/helpers/mirrorUsagePointList.ts
+++ b/src/sep2/helpers/mirrorUsagePointList.ts
@@ -41,12 +41,14 @@ export class MirrorUsagePointListHelper {
                     url: href,
                     defaultPollRateSeconds:
                         defaultPollPushRates.mirrorUsagePointPush,
-                }).on('data', () => {
+                }).on('data', (data) => {
                     void this.mirrorUsagePointSite?.updateMirrorUsagePointList({
+                        mirrorUsagePoints: data.mirrorUsagePoints,
                         mirrorUsagePointListHref: href,
                     });
 
                     void this.mirrorUsagePointDer?.updateMirrorUsagePointList({
+                        mirrorUsagePoints: data.mirrorUsagePoints,
                         mirrorUsagePointListHref: href,
                     });
                 });

--- a/src/sep2/helpers/mirrorUsagePointList.ts
+++ b/src/sep2/helpers/mirrorUsagePointList.ts
@@ -41,14 +41,12 @@ export class MirrorUsagePointListHelper {
                     url: href,
                     defaultPollRateSeconds:
                         defaultPollPushRates.mirrorUsagePointPush,
-                }).on('data', (data) => {
+                }).on('data', () => {
                     void this.mirrorUsagePointSite?.updateMirrorUsagePointList({
-                        mirrorUsagePoints: data.mirrorUsagePoints,
                         mirrorUsagePointListHref: href,
                     });
 
                     void this.mirrorUsagePointDer?.updateMirrorUsagePointList({
-                        mirrorUsagePoints: data.mirrorUsagePoints,
                         mirrorUsagePointListHref: href,
                     });
                 });

--- a/src/sep2/helpers/mirrorUsagePointSite.ts
+++ b/src/sep2/helpers/mirrorUsagePointSite.ts
@@ -1,5 +1,4 @@
 import { RoleFlagsType } from '../models/roleFlagsType.js';
-import { getSamplesIntervalSeconds } from '../../coordinator/helpers/sampleBase.js';
 import type {
     AvgMaxMin,
     NoPhaseMeasurement,
@@ -16,21 +15,463 @@ import { DataQualifierType } from '../models/dataQualifierType.js';
 import { FlowDirectionType } from '../models/flowDirectionType.js';
 import { PhaseCode } from '../models/phaseCode.js';
 import { UomType } from '../models/uomType.js';
+import type { MirrorMeterReadingDefinitions } from './mirrorUsagePointBase.js';
 import { MirrorUsagePointHelperBase } from './mirrorUsagePointBase.js';
 import { logger as pinoLogger } from '../../helpers/logger.js';
 import type { SiteSample } from '../../meters/siteSample.js';
+import { CommodityType } from '../models/commodityType.js';
+import { KindType } from '../models/kindType.js';
+import type { SEP2Client } from '../client.js';
+import { objectEntriesWithType } from '../../helpers/object.js';
 
 type SiteReading = {
-    intervalSeconds: number;
     realPower: AvgMaxMin<PerPhaseNetMeasurement | NoPhaseMeasurement>;
     reactivePower: AvgMaxMin<PerPhaseNetMeasurement | NoPhaseMeasurement>;
     voltage: AvgMaxMin<PerPhaseMeasurement>;
     frequency: AvgMaxMin<number> | null;
 };
 
+const mirrorMeterReadingDefinitions = {
+    realPowerNetAverage: {
+        description: 'Average Real Power (W) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseAAverage: {
+        description: 'Average Real Power (W) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseBAverage: {
+        description: 'Average Real Power (W) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseCAverage: {
+        description: 'Average Real Power (W) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerNetMaximum: {
+        description: 'Maximum Real Power (W) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseAMaximum: {
+        description: 'Maximum Real Power (W) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseBMaximum: {
+        description: 'Maximum Real Power (W) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseCMaximum: {
+        description: 'Maximum Real Power (W) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerNetMinimum: {
+        description: 'Minimum Real Power (W) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseAMinimum: {
+        description: 'Minimum Real Power (W) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseBMinimum: {
+        description: 'Minimum Real Power (W) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    realPowerPhaseCMinimum: {
+        description: 'Minimum Real Power (W) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.W,
+        },
+    },
+    reactivePowerNetAverage: {
+        description: 'Average Reactive Power (VAR) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseAAverage: {
+        description: 'Average Reactive Power (VAR) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseBAverage: {
+        description: 'Average Reactive Power (VAR) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseCAverage: {
+        description: 'Average Reactive Power (VAR) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerNetMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseAMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseBMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseCMaximum: {
+        description: 'Maximum Reactive Power (VAR) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerNetMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Net',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseAMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Phase A',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseBMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Phase B',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseB,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    reactivePowerPhaseCMinimum: {
+        description: 'Minimum Reactive Power (VAR) - Phase C',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseC,
+            powerOfTenMultiplier: 0,
+            uom: UomType.var,
+        },
+    },
+    voltagePhaseAAverage: {
+        description: 'Average Voltage (V) - Phase AN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseAN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseBAverage: {
+        description: 'Average Voltage (V) - Phase BN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseBN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseCAverage: {
+        description: 'Average Voltage (V) - Phase CN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseCN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseAMaximum: {
+        description: 'Maximum Voltage (V) - Phase AN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseAN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseBMaximum: {
+        description: 'Maximum Voltage (V) - Phase BN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseBN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseCMaximum: {
+        description: 'Maximum Voltage (V) - Phase CN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseCN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseAMinimum: {
+        description: 'Minimum Voltage (V) - Phase AN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseAN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseBMinimum: {
+        description: 'Minimum Voltage (V) - Phase BN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseBN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    voltagePhaseCMinimum: {
+        description: 'Minimum Voltage (V) - Phase CN',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.PhaseCN,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Voltage,
+        },
+    },
+    frequencyAverage: {
+        description: 'Average Frequency (Hz)',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Hz,
+        },
+    },
+    frequencyMaximum: {
+        description: 'Maximum Frequency (Hz)',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Maximum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Hz,
+        },
+    },
+    frequencyMinimum: {
+        description: 'Minimum Frequency (Hz)',
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Minimum,
+            flowDirection: FlowDirectionType.Forward,
+            phase: PhaseCode.NotApplicable,
+            powerOfTenMultiplier: 0,
+            uom: UomType.Hz,
+        },
+    },
+} satisfies Record<string, MirrorMeterReadingDefinitions>;
+
+type SiteMirrorMeterReadingKeys = keyof typeof mirrorMeterReadingDefinitions;
+
 export class MirrorUsagePointSiteHelper extends MirrorUsagePointHelperBase<
     SiteSample,
-    SiteReading
+    SiteReading,
+    SiteMirrorMeterReadingKeys
 > {
     protected roleFlags =
         RoleFlagsType.isPremisesAggregationPoint | RoleFlagsType.isMirror;
@@ -38,10 +479,29 @@ export class MirrorUsagePointSiteHelper extends MirrorUsagePointHelperBase<
     protected logger = pinoLogger.child({
         module: 'MirrorUsagePointSiteHelper',
     });
+    protected mirrorMeterReadingMrids: Record<
+        SiteMirrorMeterReadingKeys,
+        string
+    >;
+
+    constructor({ client }: { client: SEP2Client }) {
+        super({ client });
+
+        this.mirrorMeterReadingMrids = Object.fromEntries(
+            objectEntriesWithType(mirrorMeterReadingDefinitions).map(
+                ([key, value]) => [
+                    key,
+                    this.client.generateMeterReadingMrid({
+                        roleFlags: this.roleFlags,
+                        description: value.description,
+                    }),
+                ],
+            ),
+        ) as Record<SiteMirrorMeterReadingKeys, string>;
+    }
 
     protected getReadingFromSamples(samples: SiteSample[]): SiteReading {
         return {
-            intervalSeconds: getSamplesIntervalSeconds(samples),
             realPower: getAvgMaxMinOfPerPhaseNetOrNoPhaseMeasurements(
                 assertPerPhaseNetOrNoPhaseMeasurementArray(
                     samples.map((s) => s.realPower),
@@ -61,482 +521,113 @@ export class MirrorUsagePointSiteHelper extends MirrorUsagePointHelperBase<
         };
     }
 
-    protected postRealPower({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: SiteReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        const postReading = ({
-            phase,
-            dataQualifier,
-            description,
-            value,
-        }: {
-            phase: PhaseCode;
-            dataQualifier: DataQualifierType;
-            description: string;
-            value: number;
-        }) =>
-            this.sendMirrorMeterReading({
-                phase,
-                flowDirection: FlowDirectionType.Forward,
-                dataQualifier,
-                description,
-                value,
-                uom: UomType.W,
-                lastUpdateTime,
-                nextUpdateTime,
-                intervalLength: reading.intervalSeconds,
-            });
-
-        switch (reading.realPower.average.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Real Power (W)',
-                    value: reading.realPower.average.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Real Power (W) - Net',
-                    value: reading.realPower.average.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Real Power (W) - Phase A',
-                    value: reading.realPower.average.phaseA,
-                });
-                if (reading.realPower.average.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Real Power (W) - Phase B',
-                        value: reading.realPower.average.phaseB,
-                    });
-                }
-                if (reading.realPower.average.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Real Power (W) - Phase C',
-                        value: reading.realPower.average.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.realPower.maximum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Real Power (W)',
-                    value: reading.realPower.maximum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Real Power (W) - Net',
-                    value: reading.realPower.maximum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Real Power (W) - Phase A',
-                    value: reading.realPower.maximum.phaseA,
-                });
-                if (reading.realPower.maximum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Real Power (W) - Phase B',
-                        value: reading.realPower.maximum.phaseB,
-                    });
-                }
-                if (reading.realPower.maximum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Real Power (W) - Phase C',
-                        value: reading.realPower.maximum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.realPower.minimum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Real Power (W)',
-                    value: reading.realPower.minimum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Real Power (W) - Net',
-                    value: reading.realPower.minimum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Real Power (W) - Phase A',
-                    value: reading.realPower.minimum.phaseA,
-                });
-                if (reading.realPower.minimum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Real Power (W) - Phase B',
-                        value: reading.realPower.minimum.phaseB,
-                    });
-                }
-                if (reading.realPower.minimum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Real Power (W) - Phase C',
-                        value: reading.realPower.minimum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
+    protected override getReadingMrid(key: SiteMirrorMeterReadingKeys): string {
+        return this.mirrorMeterReadingMrids[key];
     }
 
-    protected postReactivePower({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: SiteReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        const postReading = ({
-            phase,
-            dataQualifier,
-            description,
-            value,
-        }: {
-            phase: PhaseCode;
-            dataQualifier: DataQualifierType;
-            description: string;
-            value: number;
-        }) =>
-            this.sendMirrorMeterReading({
-                phase,
-                flowDirection: FlowDirectionType.Forward,
-                dataQualifier,
-                description,
-                value,
-                uom: UomType.var,
-                lastUpdateTime,
-                nextUpdateTime,
-                intervalLength: reading.intervalSeconds,
-            });
-
-        switch (reading.reactivePower.average.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Reactive Power (VAR)',
-                    value: reading.reactivePower.average.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Reactive Power (VAR) - Net',
-                    value: reading.reactivePower.average.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Average,
-                    description: 'Average Reactive Power (VAR) - Phase A',
-                    value: reading.reactivePower.average.phaseA,
-                });
-                if (reading.reactivePower.average.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Reactive Power (VAR) - Phase B',
-                        value: reading.reactivePower.average.phaseB,
-                    });
-                }
-                if (reading.reactivePower.average.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Average,
-                        description: 'Average Reactive Power (VAR) - Phase C',
-                        value: reading.reactivePower.average.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.reactivePower.maximum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Reactive Power (VAR)',
-                    value: reading.reactivePower.maximum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Reactive Power (VAR) - Net',
-                    value: reading.reactivePower.maximum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Maximum,
-                    description: 'Maximum Reactive Power (VAR) - Phase A',
-                    value: reading.reactivePower.maximum.phaseA,
-                });
-                if (reading.reactivePower.maximum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Reactive Power (VAR) - Phase B',
-                        value: reading.reactivePower.maximum.phaseB,
-                    });
-                }
-                if (reading.reactivePower.maximum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Maximum,
-                        description: 'Maximum Reactive Power (VAR) - Phase C',
-                        value: reading.reactivePower.maximum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
-
-        switch (reading.reactivePower.minimum.type) {
-            case 'noPhase': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Reactive Power (VAR)',
-                    value: reading.reactivePower.minimum.value,
-                });
-                break;
-            }
-            case 'perPhaseNet': {
-                postReading({
-                    phase: PhaseCode.NotApplicable,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Reactive Power (VAR) - Net',
-                    value: reading.reactivePower.minimum.net,
-                });
-                postReading({
-                    phase: PhaseCode.PhaseA,
-                    dataQualifier: DataQualifierType.Minimum,
-                    description: 'Minimum Reactive Power (VAR) - Phase A',
-                    value: reading.reactivePower.minimum.phaseA,
-                });
-                if (reading.reactivePower.minimum.phaseB) {
-                    postReading({
-                        phase: PhaseCode.PhaseB,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Reactive Power (VAR) - Phase B',
-                        value: reading.reactivePower.minimum.phaseB,
-                    });
-                }
-                if (reading.reactivePower.minimum.phaseC) {
-                    postReading({
-                        phase: PhaseCode.PhaseC,
-                        dataQualifier: DataQualifierType.Minimum,
-                        description: 'Minimum Reactive Power (VAR) - Phase C',
-                        value: reading.reactivePower.minimum.phaseC,
-                    });
-                }
-                break;
-            }
-        }
+    protected override getReadingDefintions(): Record<
+        SiteMirrorMeterReadingKeys,
+        MirrorMeterReadingDefinitions
+    > {
+        return mirrorMeterReadingDefinitions;
     }
 
-    protected postVoltage({
+    protected override getReadingValues({
         reading,
-        lastUpdateTime,
-        nextUpdateTime,
     }: {
         reading: SiteReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        const postReading = ({
-            phase,
-            dataQualifier,
-            description,
-            value,
-        }: {
-            phase: PhaseCode;
-            dataQualifier: DataQualifierType;
-            description: string;
-            value: number;
-        }) =>
-            this.sendMirrorMeterReading({
-                phase,
-                flowDirection: FlowDirectionType.Forward,
-                dataQualifier,
-                description,
-                value,
-                uom: UomType.Voltage,
-                lastUpdateTime,
-                nextUpdateTime,
-                intervalLength: reading.intervalSeconds,
-            });
-
-        // average
-        postReading({
-            phase: PhaseCode.PhaseAN,
-            dataQualifier: DataQualifierType.Average,
-            description: 'Average Voltage (V) - Phase AN',
-            value: reading.voltage.average.phaseA,
-        });
-        if (reading.voltage.average.phaseB) {
-            postReading({
-                phase: PhaseCode.PhaseBN,
-                dataQualifier: DataQualifierType.Average,
-                description: 'Average Voltage (V) - Phase BN',
-                value: reading.voltage.average.phaseB,
-            });
-        }
-        if (reading.voltage.average.phaseC) {
-            postReading({
-                phase: PhaseCode.PhaseCN,
-                dataQualifier: DataQualifierType.Average,
-                description: 'Average Voltage (V) - Phase CN',
-                value: reading.voltage.average.phaseC,
-            });
-        }
-
-        // maximum
-        postReading({
-            phase: PhaseCode.PhaseAN,
-            dataQualifier: DataQualifierType.Maximum,
-            description: 'Maximum Voltage (V) - Phase AN',
-            value: reading.voltage.maximum.phaseA,
-        });
-        if (reading.voltage.maximum.phaseB) {
-            postReading({
-                phase: PhaseCode.PhaseBN,
-                dataQualifier: DataQualifierType.Maximum,
-                description: 'Maximum Voltage (V) - Phase BN',
-                value: reading.voltage.maximum.phaseB,
-            });
-        }
-        if (reading.voltage.maximum.phaseC) {
-            postReading({
-                phase: PhaseCode.PhaseCN,
-                dataQualifier: DataQualifierType.Maximum,
-                description: 'Maximum Voltage (V) - Phase CN',
-                value: reading.voltage.maximum.phaseC,
-            });
-        }
-
-        // minimum
-        postReading({
-            phase: PhaseCode.PhaseAN,
-            dataQualifier: DataQualifierType.Minimum,
-            description: 'Minimum Voltage (V) - Phase AN',
-            value: reading.voltage.minimum.phaseA,
-        });
-        if (reading.voltage.minimum.phaseB) {
-            postReading({
-                phase: PhaseCode.PhaseBN,
-                dataQualifier: DataQualifierType.Minimum,
-                description: 'Minimum Voltage (V) - Phase BN',
-                value: reading.voltage.minimum.phaseB,
-            });
-        }
-        if (reading.voltage.minimum.phaseC) {
-            postReading({
-                phase: PhaseCode.PhaseCN,
-                dataQualifier: DataQualifierType.Minimum,
-                description: 'Minimum Voltage (V) - Phase CN',
-                value: reading.voltage.minimum.phaseC,
-            });
-        }
-    }
-
-    protected postFrequency({
-        reading,
-        lastUpdateTime,
-        nextUpdateTime,
-    }: {
-        reading: SiteReading;
-        lastUpdateTime: Date;
-        nextUpdateTime: Date;
-    }) {
-        if (reading.frequency === null) {
-            return;
-        }
-
-        void this.sendMirrorMeterReading({
-            phase: PhaseCode.NotApplicable,
-            flowDirection: FlowDirectionType.Forward,
-            dataQualifier: DataQualifierType.Average,
-            description: 'Average Frequency (Hz)',
-            value: reading.frequency.average,
-            uom: UomType.Hz,
-            intervalLength: reading.intervalSeconds,
-            lastUpdateTime,
-            nextUpdateTime,
-        });
-
-        void this.sendMirrorMeterReading({
-            phase: PhaseCode.NotApplicable,
-            flowDirection: FlowDirectionType.Forward,
-            dataQualifier: DataQualifierType.Maximum,
-            description: 'Maximum Frequency (Hz)',
-            value: reading.frequency.maximum,
-            uom: UomType.Hz,
-            intervalLength: reading.intervalSeconds,
-            lastUpdateTime,
-            nextUpdateTime,
-        });
-
-        void this.sendMirrorMeterReading({
-            phase: PhaseCode.NotApplicable,
-            flowDirection: FlowDirectionType.Forward,
-            dataQualifier: DataQualifierType.Minimum,
-            description: 'Minimum Frequency (Hz)',
-            value: reading.frequency.minimum,
-            uom: UomType.Hz,
-            intervalLength: reading.intervalSeconds,
-            lastUpdateTime,
-            nextUpdateTime,
-        });
+    }): Record<SiteMirrorMeterReadingKeys, number | null> {
+        return {
+            realPowerNetAverage: reading.realPower.average.net,
+            realPowerPhaseAAverage:
+                reading.realPower.average.type === 'perPhaseNet'
+                    ? reading.realPower.average.phaseA
+                    : null,
+            realPowerPhaseBAverage:
+                reading.realPower.average.type === 'perPhaseNet'
+                    ? reading.realPower.average.phaseB
+                    : null,
+            realPowerPhaseCAverage:
+                reading.realPower.average.type === 'perPhaseNet'
+                    ? reading.realPower.average.phaseC
+                    : null,
+            realPowerNetMaximum: reading.realPower.maximum.net,
+            realPowerPhaseAMaximum:
+                reading.realPower.maximum.type === 'perPhaseNet'
+                    ? reading.realPower.maximum.phaseA
+                    : null,
+            realPowerPhaseBMaximum:
+                reading.realPower.maximum.type === 'perPhaseNet'
+                    ? reading.realPower.maximum.phaseB
+                    : null,
+            realPowerPhaseCMaximum:
+                reading.realPower.maximum.type === 'perPhaseNet'
+                    ? reading.realPower.maximum.phaseC
+                    : null,
+            realPowerNetMinimum: reading.realPower.minimum.net,
+            realPowerPhaseAMinimum:
+                reading.realPower.minimum.type === 'perPhaseNet'
+                    ? reading.realPower.minimum.phaseA
+                    : null,
+            realPowerPhaseBMinimum:
+                reading.realPower.minimum.type === 'perPhaseNet'
+                    ? reading.realPower.minimum.phaseB
+                    : null,
+            realPowerPhaseCMinimum:
+                reading.realPower.minimum.type === 'perPhaseNet'
+                    ? reading.realPower.minimum.phaseC
+                    : null,
+            reactivePowerNetAverage: reading.reactivePower.average.net,
+            reactivePowerPhaseAAverage:
+                reading.reactivePower.average.type === 'perPhaseNet'
+                    ? reading.reactivePower.average.phaseA
+                    : null,
+            reactivePowerPhaseBAverage:
+                reading.reactivePower.average.type === 'perPhaseNet'
+                    ? reading.reactivePower.average.phaseB
+                    : null,
+            reactivePowerPhaseCAverage:
+                reading.reactivePower.average.type === 'perPhaseNet'
+                    ? reading.reactivePower.average.phaseC
+                    : null,
+            reactivePowerNetMaximum: reading.reactivePower.maximum.net,
+            reactivePowerPhaseAMaximum:
+                reading.reactivePower.maximum.type === 'perPhaseNet'
+                    ? reading.reactivePower.maximum.phaseA
+                    : null,
+            reactivePowerPhaseBMaximum:
+                reading.reactivePower.maximum.type === 'perPhaseNet'
+                    ? reading.reactivePower.maximum.phaseB
+                    : null,
+            reactivePowerPhaseCMaximum:
+                reading.reactivePower.maximum.type === 'perPhaseNet'
+                    ? reading.reactivePower.maximum.phaseC
+                    : null,
+            reactivePowerNetMinimum: reading.reactivePower.minimum.net,
+            reactivePowerPhaseAMinimum:
+                reading.reactivePower.minimum.type === 'perPhaseNet'
+                    ? reading.reactivePower.minimum.phaseA
+                    : null,
+            reactivePowerPhaseBMinimum:
+                reading.reactivePower.minimum.type === 'perPhaseNet'
+                    ? reading.reactivePower.minimum.phaseB
+                    : null,
+            reactivePowerPhaseCMinimum:
+                reading.reactivePower.minimum.type === 'perPhaseNet'
+                    ? reading.reactivePower.minimum.phaseC
+                    : null,
+            voltagePhaseAAverage: reading.voltage.average.phaseA,
+            voltagePhaseBAverage: reading.voltage.average.phaseB,
+            voltagePhaseCAverage: reading.voltage.average.phaseC,
+            voltagePhaseAMaximum: reading.voltage.maximum.phaseA,
+            voltagePhaseBMaximum: reading.voltage.maximum.phaseB,
+            voltagePhaseCMaximum: reading.voltage.maximum.phaseC,
+            voltagePhaseAMinimum: reading.voltage.minimum.phaseA,
+            voltagePhaseBMinimum: reading.voltage.minimum.phaseB,
+            voltagePhaseCMinimum: reading.voltage.minimum.phaseC,
+            frequencyAverage: reading.frequency?.average ?? null,
+            frequencyMaximum: reading.frequency?.maximum ?? null,
+            frequencyMinimum: reading.frequency?.minimum ?? null,
+        };
     }
 }

--- a/src/sep2/models/dateTimeInterval.ts
+++ b/src/sep2/models/dateTimeInterval.ts
@@ -1,0 +1,29 @@
+import { safeParseIntString } from '../../helpers/number.js';
+import { assertString } from '../helpers/assert.js';
+import { stringIntToDate } from '../helpers/date.js';
+
+export type DateTimeInterval = {
+    /**
+     * Duration of the interval, in seconds.
+     */
+    duration: number;
+    /**
+     * Date and time of the start of the interval.
+     */
+    start: Date;
+};
+
+export function parseDateTimeIntervalXmlObject(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    xmlObject: any,
+): DateTimeInterval {
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    const start = stringIntToDate(assertString(xmlObject['start'][0]));
+    const duration = safeParseIntString(assertString(xmlObject['duration'][0]));
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+
+    return {
+        start,
+        duration,
+    };
+}

--- a/src/sep2/models/event.ts
+++ b/src/sep2/models/event.ts
@@ -1,6 +1,9 @@
-import { safeParseIntString } from '../../helpers/number.js';
 import { assertString } from '../helpers/assert.js';
 import { stringIntToDate } from '../helpers/date.js';
+import {
+    parseDateTimeIntervalXmlObject,
+    type DateTimeInterval,
+} from './dateTimeInterval.js';
 import { parseEventStatusXmlObject, type EventStatus } from './eventStatus.js';
 import {
     parseIdentifiedObjectXmlObject,
@@ -15,15 +18,9 @@ import {
     type SubscribableResource,
 } from './subscribableResource.js';
 
-type Interval = {
-    // duration in seconds
-    duration: number;
-    start: Date;
-};
-
 export type Event = {
     creationTime: Date;
-    interval: Interval;
+    interval: DateTimeInterval;
     eventStatus: EventStatus;
 } & RespondableResource &
     SubscribableResource &
@@ -40,7 +37,7 @@ export function parseEventXmlObject(
     const creationTime = stringIntToDate(
         assertString(xmlObject['creationTime'][0]),
     );
-    const interval = parseIntervalXmlObject(xmlObject['interval'][0]);
+    const interval = parseDateTimeIntervalXmlObject(xmlObject['interval'][0]);
     const eventStatus = parseEventStatusXmlObject(xmlObject['EventStatus'][0]);
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 
@@ -51,20 +48,5 @@ export function parseEventXmlObject(
         creationTime,
         interval,
         eventStatus,
-    };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function parseIntervalXmlObject(xmlObject: any): Interval {
-    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-    const start = stringIntToDate(assertString(xmlObject['start'][0]));
-    const durationSeconds = safeParseIntString(
-        assertString(xmlObject['duration'][0]),
-    );
-    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-
-    return {
-        start,
-        duration: durationSeconds,
     };
 }

--- a/src/sep2/models/mirrorMeterReading.test.ts
+++ b/src/sep2/models/mirrorMeterReading.test.ts
@@ -20,6 +20,10 @@ it('should generate MirrorMeterReading XML', () => {
         nextUpdateTime: new Date(1659657180 * 1000),
         version: 0,
         Reading: {
+            timePeriod: {
+                start: new Date(1659656880 * 1000),
+                duration: 300,
+            },
             qualityFlags: QualityFlags.Valid,
             value: 1500,
         },
@@ -45,16 +49,20 @@ it('should generate MirrorMeterReading XML', () => {
     <nextUpdateTime>1659657180</nextUpdateTime>
     <version>0</version>
     <Reading>
-        <qualityFlags>0001</qualityFlags>
         <value>1500</value>
+        <qualityFlags>0001</qualityFlags>
+        <timePeriod>
+            <start>1659656880</start>
+            <duration>300</duration>
+        </timePeriod>
     </Reading>
     <ReadingType>
         <commodity>1</commodity>
         <kind>37</kind>
         <dataQualifier>2</dataQualifier>
         <flowDirection>19</flowDirection>
-        <powerOfTenMultiplier>0</powerOfTenMultiplier>
         <intervalLength>300</intervalLength>
+        <powerOfTenMultiplier>0</powerOfTenMultiplier>
         <uom>38</uom>
         <phase>128</phase>
     </ReadingType>
@@ -94,16 +102,16 @@ it('should generate MirrorMeterReading object', () => {
     <nextUpdateTime>1659657180</nextUpdateTime>
     <version>0</version>
     <Reading>
-        <qualityFlags>0001</qualityFlags>
         <value>1500</value>
+        <qualityFlags>0001</qualityFlags>
     </Reading>
     <ReadingType>
         <commodity>1</commodity>
         <kind>37</kind>
         <dataQualifier>2</dataQualifier>
         <flowDirection>19</flowDirection>
-        <powerOfTenMultiplier>0</powerOfTenMultiplier>
         <intervalLength>300</intervalLength>
+        <powerOfTenMultiplier>0</powerOfTenMultiplier>
         <uom>38</uom>
         <phase>128</phase>
     </ReadingType>

--- a/src/sep2/models/mirrorMeterReading.test.ts
+++ b/src/sep2/models/mirrorMeterReading.test.ts
@@ -61,9 +61,9 @@ it('should generate MirrorMeterReading XML', () => {
         <kind>37</kind>
         <dataQualifier>2</dataQualifier>
         <flowDirection>19</flowDirection>
-        <intervalLength>300</intervalLength>
         <powerOfTenMultiplier>0</powerOfTenMultiplier>
         <uom>38</uom>
+        <intervalLength>300</intervalLength>
         <phase>128</phase>
     </ReadingType>
 </MirrorMeterReading>`);
@@ -110,9 +110,9 @@ it('should generate MirrorMeterReading object', () => {
         <kind>37</kind>
         <dataQualifier>2</dataQualifier>
         <flowDirection>19</flowDirection>
-        <intervalLength>300</intervalLength>
         <powerOfTenMultiplier>0</powerOfTenMultiplier>
         <uom>38</uom>
+        <intervalLength>300</intervalLength>
         <phase>128</phase>
     </ReadingType>
 </root>`);

--- a/src/sep2/models/mirrorMeterReading.test.ts
+++ b/src/sep2/models/mirrorMeterReading.test.ts
@@ -1,6 +1,9 @@
 import { it, expect } from 'vitest';
 import { objectToXml } from '../helpers/xml.js';
-import { generateMirrorMeterReadingResponse } from './mirrorMeterReading.js';
+import {
+    generateMirrorMeterReadingResponse,
+    generateMirrorMeterReadingObject,
+} from './mirrorMeterReading.js';
 import { QualityFlags } from './qualityFlags.js';
 import { CommodityType } from './commodityType.js';
 import { KindType } from './kindType.js';
@@ -56,4 +59,53 @@ it('should generate MirrorMeterReading XML', () => {
         <phase>128</phase>
     </ReadingType>
 </MirrorMeterReading>`);
+});
+
+it('should generate MirrorMeterReading object', () => {
+    const response = generateMirrorMeterReadingObject({
+        mRID: 'AA00007301',
+        description: 'Average W Reading - Phase A (Site)',
+        lastUpdateTime: new Date(1659656880 * 1000),
+        nextUpdateTime: new Date(1659657180 * 1000),
+        version: 0,
+        Reading: {
+            qualityFlags: QualityFlags.Valid,
+            value: 1500,
+        },
+        ReadingType: {
+            commodity: CommodityType.ElectricitySecondaryMeteredValue,
+            kind: KindType.Power,
+            dataQualifier: DataQualifierType.Average,
+            flowDirection: FlowDirectionType.Reverse,
+            phase: PhaseCode.PhaseA,
+            powerOfTenMultiplier: 0,
+            intervalLength: 300,
+            uom: UomType.W,
+        },
+    });
+
+    const xml = objectToXml(response);
+
+    expect(xml).toBe(`<?xml version="1.0"?>
+<root>
+    <mRID>AA00007301</mRID>
+    <description>Average W Reading - Phase A (Site)</description>
+    <lastUpdateTime>1659656880</lastUpdateTime>
+    <nextUpdateTime>1659657180</nextUpdateTime>
+    <version>0</version>
+    <Reading>
+        <qualityFlags>0001</qualityFlags>
+        <value>1500</value>
+    </Reading>
+    <ReadingType>
+        <commodity>1</commodity>
+        <kind>37</kind>
+        <dataQualifier>2</dataQualifier>
+        <flowDirection>19</flowDirection>
+        <powerOfTenMultiplier>0</powerOfTenMultiplier>
+        <intervalLength>300</intervalLength>
+        <uom>38</uom>
+        <phase>128</phase>
+    </ReadingType>
+</root>`);
 });

--- a/src/sep2/models/mirrorMeterReading.ts
+++ b/src/sep2/models/mirrorMeterReading.ts
@@ -12,8 +12,8 @@ import type { IdentifiedObject } from './identifiedObject.js';
 import type { DateTimeInterval } from './dateTimeInterval.js';
 
 export type MirrorMeterReading = {
-    lastUpdateTime: Date;
-    nextUpdateTime: Date;
+    lastUpdateTime?: Date;
+    nextUpdateTime?: Date;
     Reading?: {
         timePeriod?: DateTimeInterval;
         qualityFlags?: QualityFlags;
@@ -26,7 +26,7 @@ export type MirrorMeterReading = {
         flowDirection: FlowDirectionType;
         phase: PhaseCode;
         powerOfTenMultiplier: number;
-        intervalLength: number;
+        intervalLength?: number;
         uom: UomType;
     };
 } & IdentifiedObject;
@@ -57,11 +57,23 @@ export function generateMirrorMeterReadingObject({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const response: Record<string, any> = {
         mRID,
-        description,
-        lastUpdateTime: dateToStringSeconds(lastUpdateTime),
-        nextUpdateTime: dateToStringSeconds(nextUpdateTime),
-        version,
     };
+
+    if (description) {
+        response['description'] = description;
+    }
+
+    if (lastUpdateTime) {
+        response['lastUpdateTime'] = dateToStringSeconds(lastUpdateTime);
+    }
+
+    if (nextUpdateTime) {
+        response['nextUpdateTime'] = dateToStringSeconds(nextUpdateTime);
+    }
+
+    if (version !== undefined) {
+        response['version'] = version;
+    }
 
     if (Reading) {
         response['Reading'] = {
@@ -90,10 +102,14 @@ export function generateMirrorMeterReadingObject({
             kind: ReadingType.kind,
             dataQualifier: ReadingType.dataQualifier,
             flowDirection: ReadingType.flowDirection,
-            intervalLength: ReadingType.intervalLength,
             powerOfTenMultiplier: ReadingType.powerOfTenMultiplier,
             uom: ReadingType.uom,
         };
+
+        if (ReadingType.intervalLength !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            response['ReadingType'].intervalLength = ReadingType.intervalLength;
+        }
 
         // the SEP2 server can't seem to handle phase code 0 even though it is documented as a valid value
         // conditionally set phase if it's not 0

--- a/src/sep2/models/mirrorMeterReading.ts
+++ b/src/sep2/models/mirrorMeterReading.ts
@@ -10,7 +10,6 @@ import type { QualityFlags } from './qualityFlags.js';
 import type { UomType } from './uomType.js';
 import type { IdentifiedObject } from './identifiedObject.js';
 
-// reading MRID should be a random UUIDv4 with the PEN
 export type MirrorMeterReading = {
     lastUpdateTime: Date;
     nextUpdateTime: Date;
@@ -31,7 +30,21 @@ export type MirrorMeterReading = {
     };
 } & IdentifiedObject;
 
-export function generateMirrorMeterReadingResponse({
+export function generateMirrorMeterReadingResponse(
+    mirrorMeterReading: MirrorMeterReading,
+) {
+    const response = {
+        MirrorMeterReading: {
+            $: { xmlns: xmlns._ },
+            ...generateMirrorMeterReadingObject(mirrorMeterReading),
+        },
+    };
+
+    return response;
+}
+
+// MirrorMeterReading object to be nested inside MirrorUsagePoint
+export function generateMirrorMeterReadingObject({
     mRID,
     description,
     lastUpdateTime,
@@ -41,30 +54,24 @@ export function generateMirrorMeterReadingResponse({
     ReadingType,
 }: MirrorMeterReading) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response: { MirrorMeterReading: any } = {
-        MirrorMeterReading: {
-            $: { xmlns: xmlns._ },
-            mRID,
-            description,
-            lastUpdateTime: dateToStringSeconds(lastUpdateTime),
-            nextUpdateTime: dateToStringSeconds(nextUpdateTime),
-            version,
-            Reading: {
-                qualityFlags: numberToHex(Reading.qualityFlags).padStart(
-                    4,
-                    '0',
-                ),
-                value: Reading.value,
-            },
-            ReadingType: {
-                commodity: ReadingType.commodity,
-                kind: ReadingType.kind,
-                dataQualifier: ReadingType.dataQualifier,
-                flowDirection: ReadingType.flowDirection,
-                powerOfTenMultiplier: ReadingType.powerOfTenMultiplier,
-                intervalLength: ReadingType.intervalLength,
-                uom: ReadingType.uom,
-            },
+    const response: Record<string, any> = {
+        mRID,
+        description,
+        lastUpdateTime: dateToStringSeconds(lastUpdateTime),
+        nextUpdateTime: dateToStringSeconds(nextUpdateTime),
+        version,
+        Reading: {
+            qualityFlags: numberToHex(Reading.qualityFlags).padStart(4, '0'),
+            value: Reading.value,
+        },
+        ReadingType: {
+            commodity: ReadingType.commodity,
+            kind: ReadingType.kind,
+            dataQualifier: ReadingType.dataQualifier,
+            flowDirection: ReadingType.flowDirection,
+            powerOfTenMultiplier: ReadingType.powerOfTenMultiplier,
+            intervalLength: ReadingType.intervalLength,
+            uom: ReadingType.uom,
         },
     };
 
@@ -77,7 +84,7 @@ export function generateMirrorMeterReadingResponse({
     //   }
     if (ReadingType.phase !== PhaseCode.NotApplicable) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        response.MirrorMeterReading.ReadingType.phase = ReadingType.phase;
+        response['ReadingType'].phase = ReadingType.phase;
     }
 
     return response;

--- a/src/sep2/models/mirrorUsagePoint.test.ts
+++ b/src/sep2/models/mirrorUsagePoint.test.ts
@@ -179,9 +179,9 @@ describe('generateMirrorUsagePointResponse', () => {
             <kind>37</kind>
             <dataQualifier>2</dataQualifier>
             <flowDirection>19</flowDirection>
-            <intervalLength>300</intervalLength>
             <powerOfTenMultiplier>0</powerOfTenMultiplier>
             <uom>38</uom>
+            <intervalLength>300</intervalLength>
             <phase>128</phase>
         </ReadingType>
     </MirrorMeterReading>
@@ -200,9 +200,9 @@ describe('generateMirrorUsagePointResponse', () => {
             <kind>37</kind>
             <dataQualifier>2</dataQualifier>
             <flowDirection>19</flowDirection>
-            <intervalLength>300</intervalLength>
             <powerOfTenMultiplier>0</powerOfTenMultiplier>
             <uom>38</uom>
+            <intervalLength>300</intervalLength>
             <phase>64</phase>
         </ReadingType>
     </MirrorMeterReading>

--- a/src/sep2/models/mirrorUsagePoint.test.ts
+++ b/src/sep2/models/mirrorUsagePoint.test.ts
@@ -171,16 +171,16 @@ describe('generateMirrorUsagePointResponse', () => {
         <nextUpdateTime>1659657180</nextUpdateTime>
         <version>0</version>
         <Reading>
-            <qualityFlags>0001</qualityFlags>
             <value>1500</value>
+            <qualityFlags>0001</qualityFlags>
         </Reading>
         <ReadingType>
             <commodity>1</commodity>
             <kind>37</kind>
             <dataQualifier>2</dataQualifier>
             <flowDirection>19</flowDirection>
-            <powerOfTenMultiplier>0</powerOfTenMultiplier>
             <intervalLength>300</intervalLength>
+            <powerOfTenMultiplier>0</powerOfTenMultiplier>
             <uom>38</uom>
             <phase>128</phase>
         </ReadingType>
@@ -192,16 +192,16 @@ describe('generateMirrorUsagePointResponse', () => {
         <nextUpdateTime>1659657180</nextUpdateTime>
         <version>0</version>
         <Reading>
-            <qualityFlags>0001</qualityFlags>
             <value>1500</value>
+            <qualityFlags>0001</qualityFlags>
         </Reading>
         <ReadingType>
             <commodity>1</commodity>
             <kind>37</kind>
             <dataQualifier>2</dataQualifier>
             <flowDirection>19</flowDirection>
-            <powerOfTenMultiplier>0</powerOfTenMultiplier>
             <intervalLength>300</intervalLength>
+            <powerOfTenMultiplier>0</powerOfTenMultiplier>
             <uom>38</uom>
             <phase>64</phase>
         </ReadingType>

--- a/src/sep2/models/mirrorUsagePoint.test.ts
+++ b/src/sep2/models/mirrorUsagePoint.test.ts
@@ -9,6 +9,13 @@ import { RoleFlagsType } from './roleFlagsType.js';
 import { ServiceKind } from './serviceKind.js';
 import { objectToXml } from '../helpers/xml.js';
 import { UsagePointBaseStatus } from './usagePointBase.js';
+import { QualityFlags } from './qualityFlags.js';
+import { CommodityType } from './commodityType.js';
+import { KindType } from './kindType.js';
+import { DataQualifierType } from './dataQualifierType.js';
+import { FlowDirectionType } from './flowDirectionType.js';
+import { PhaseCode } from './phaseCode.js';
+import { UomType } from './uomType.js';
 
 it('should parse end device DER with XML', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -85,6 +92,120 @@ describe('generateMirrorUsagePointResponse', () => {
     <serviceCategoryKind>0</serviceCategoryKind>
     <status>1</status>
     <deviceLFDI>4075DE6031E562ACF4D9EAA765A5B2ED00057269</deviceLFDI>
+</MirrorUsagePoint>`);
+    });
+
+    it('should generate MirrorUsagePoint XML for DER with MirrorMeterReading', () => {
+        const response = generateMirrorUsagePointResponse({
+            mRID: '01E0F2357FF85E4B7EE6C64900057269',
+            description: 'DER Measurement',
+            roleFlags:
+                RoleFlagsType.isDER |
+                RoleFlagsType.isMirror |
+                RoleFlagsType.isSubmeter,
+            serviceCategoryKind: ServiceKind.Electricity,
+            status: UsagePointBaseStatus.On,
+            deviceLFDI: '4075DE6031E562ACF4D9EAA765A5B2ED00057269',
+            mirrorMeterReading: [
+                {
+                    mRID: 'AA00007301',
+                    description: 'Average W Reading - Phase A (Site)',
+                    lastUpdateTime: new Date(1659656880 * 1000),
+                    nextUpdateTime: new Date(1659657180 * 1000),
+                    version: 0,
+                    Reading: {
+                        qualityFlags: QualityFlags.Valid,
+                        value: 1500,
+                    },
+                    ReadingType: {
+                        commodity:
+                            CommodityType.ElectricitySecondaryMeteredValue,
+                        kind: KindType.Power,
+                        dataQualifier: DataQualifierType.Average,
+                        flowDirection: FlowDirectionType.Reverse,
+                        phase: PhaseCode.PhaseA,
+                        powerOfTenMultiplier: 0,
+                        intervalLength: 300,
+                        uom: UomType.W,
+                    },
+                },
+                {
+                    mRID: 'AA00007302',
+                    description: 'Average W Reading - Phase B (Site)',
+                    lastUpdateTime: new Date(1659656880 * 1000),
+                    nextUpdateTime: new Date(1659657180 * 1000),
+                    version: 0,
+                    Reading: {
+                        qualityFlags: QualityFlags.Valid,
+                        value: 1500,
+                    },
+                    ReadingType: {
+                        commodity:
+                            CommodityType.ElectricitySecondaryMeteredValue,
+                        kind: KindType.Power,
+                        dataQualifier: DataQualifierType.Average,
+                        flowDirection: FlowDirectionType.Reverse,
+                        phase: PhaseCode.PhaseB,
+                        powerOfTenMultiplier: 0,
+                        intervalLength: 300,
+                        uom: UomType.W,
+                    },
+                },
+            ],
+        });
+
+        const xml = objectToXml(response);
+
+        expect(xml).toBe(`<?xml version="1.0"?>
+<MirrorUsagePoint xmlns="urn:ieee:std:2030.5:ns">
+    <mRID>01E0F2357FF85E4B7EE6C64900057269</mRID>
+    <description>DER Measurement</description>
+    <roleFlags>49</roleFlags>
+    <serviceCategoryKind>0</serviceCategoryKind>
+    <status>1</status>
+    <deviceLFDI>4075DE6031E562ACF4D9EAA765A5B2ED00057269</deviceLFDI>
+    <MirrorMeterReading>
+        <mRID>AA00007301</mRID>
+        <description>Average W Reading - Phase A (Site)</description>
+        <lastUpdateTime>1659656880</lastUpdateTime>
+        <nextUpdateTime>1659657180</nextUpdateTime>
+        <version>0</version>
+        <Reading>
+            <qualityFlags>0001</qualityFlags>
+            <value>1500</value>
+        </Reading>
+        <ReadingType>
+            <commodity>1</commodity>
+            <kind>37</kind>
+            <dataQualifier>2</dataQualifier>
+            <flowDirection>19</flowDirection>
+            <powerOfTenMultiplier>0</powerOfTenMultiplier>
+            <intervalLength>300</intervalLength>
+            <uom>38</uom>
+            <phase>128</phase>
+        </ReadingType>
+    </MirrorMeterReading>
+    <MirrorMeterReading>
+        <mRID>AA00007302</mRID>
+        <description>Average W Reading - Phase B (Site)</description>
+        <lastUpdateTime>1659656880</lastUpdateTime>
+        <nextUpdateTime>1659657180</nextUpdateTime>
+        <version>0</version>
+        <Reading>
+            <qualityFlags>0001</qualityFlags>
+            <value>1500</value>
+        </Reading>
+        <ReadingType>
+            <commodity>1</commodity>
+            <kind>37</kind>
+            <dataQualifier>2</dataQualifier>
+            <flowDirection>19</flowDirection>
+            <powerOfTenMultiplier>0</powerOfTenMultiplier>
+            <intervalLength>300</intervalLength>
+            <uom>38</uom>
+            <phase>64</phase>
+        </ReadingType>
+    </MirrorMeterReading>
 </MirrorUsagePoint>`);
     });
 });

--- a/src/sep2/models/mirrorUsagePoint.ts
+++ b/src/sep2/models/mirrorUsagePoint.ts
@@ -1,6 +1,10 @@
 import { numberToHex } from '../../helpers/number.js';
 import { assertString } from '../helpers/assert.js';
 import { xmlns } from '../helpers/namespace.js';
+import {
+    generateMirrorMeterReadingObject,
+    type MirrorMeterReading,
+} from './mirrorMeterReading.js';
 import { parsePostRateXmlObject, type PostRate } from './postRate.js';
 import {
     parseUsagePointBaseXmlObject,
@@ -10,6 +14,7 @@ import {
 export type MirrorUsagePoint = {
     postRate?: PostRate;
     deviceLFDI: string;
+    mirrorMeterReading?: MirrorMeterReading[];
 } & UsagePointBase;
 
 export function parseMirrorUsagePointXml(
@@ -49,8 +54,10 @@ export function generateMirrorUsagePointResponse({
     serviceCategoryKind,
     status,
     deviceLFDI,
+    mirrorMeterReading,
 }: MirrorUsagePoint) {
-    return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response: { MirrorUsagePoint: any } = {
         MirrorUsagePoint: {
             $: { xmlns: xmlns._ },
             mRID,
@@ -61,4 +68,13 @@ export function generateMirrorUsagePointResponse({
             deviceLFDI,
         },
     };
+
+    if (mirrorMeterReading) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        response.MirrorUsagePoint.MirrorMeterReading = mirrorMeterReading.map(
+            (reading) => generateMirrorMeterReadingObject(reading),
+        );
+    }
+
+    return response;
 }


### PR DESCRIPTION
To meet CSIP-AUS requirements, instead of creating `MirrorUsagePoint` and then creating `MirrorMeterReading`s, create `MirrorUsagePoint` with `MirrorMeterReading` definitions (only with `ReadingType`) then send MirrorMeterReading values (only with `Reading`).