### PR TITLE
Cache fallback control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 TZ=Australia/Melbourne
 SERVER_PORT=3000
-SEP2_CERT_PATH=config/cert.pem
-SEP2_KEY_PATH=config/key.pem
+CONFIG_DIR=./config
+SEP2_CERT_FILE=cert.pem
+SEP2_KEY_FILE=key.pem
 SEP2_PEN=62223
 INFLUXDB_USERNAME=admin
 INFLUXDB_PASSWORD=password

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,14 +7,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    
     - uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: 'npm'
+
     - run: npm ci
+
+    - name: Set up .env
+      run: cp .env.example .env
+
     - run: npm run prebuild
+
     - run: npm run lint
+    
     - run: npm run build
+
     - name: Check for uncommitted files
       run: git diff --exit-code
+
     - run: npm test

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { readFileSync } from 'fs';
+import { env } from './env.js';
 
 const sunspecModbusSchema = {
     ip: z
@@ -162,10 +163,14 @@ export const configSchema = z.object({
 
 export type Config = z.infer<typeof configSchema>;
 
+export function getConfigPath() {
+    return `${env.CONFIG_DIR}/config.json`;
+}
+
 export function getConfig() {
     const configJson = (() => {
         try {
-            return readFileSync('./config/config.json', 'utf8');
+            return readFileSync(getConfigPath(), 'utf8');
         } catch {
             throw new Error(`Error reading ./config/config.json`);
         }

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,11 +1,14 @@
+import 'dotenv/config';
 import z from 'zod';
 import { safeParseIntString } from './number.js';
 import { logger } from './logger.js';
 
 const envSchema = z.object({
+    TZ: z.string(),
     SERVER_PORT: z.string().transform(safeParseIntString),
-    SEP2_CERT_PATH: z.string(),
-    SEP2_KEY_PATH: z.string(),
+    CONFIG_DIR: z.string(),
+    SEP2_CERT_FILE: z.string(),
+    SEP2_KEY_FILE: z.string(),
     SEP2_PEN: z.string(),
     INFLUXDB_USERNAME: z.string(),
     INFLUXDB_PASSWORD: z.string(),

--- a/src/helpers/influxdb.ts
+++ b/src/helpers/influxdb.ts
@@ -3,11 +3,11 @@ import type {
     ControlType,
     RandomizedControlSchedule,
 } from '../sep2/helpers/controlScheduler.js';
-import type { FallbackControl } from '../sep2/helpers/derControls.js';
 import { numberWithPow10 } from './number.js';
 import type { SiteSample } from '../meters/siteSample.js';
 import type { DerSample } from '../coordinator/helpers/derSample.js';
 import type { InverterControlLimit } from '../coordinator/helpers/inverterController.js';
+import type { FallbackControl } from '../sep2/helpers/fallbackControl.js';
 
 const influxDB = new InfluxDB({
     url: `http://influxdb:${process.env['INFLUXDB_PORT'] ?? 8086}`,

--- a/src/helpers/sep2Cert.ts
+++ b/src/helpers/sep2Cert.ts
@@ -1,15 +1,17 @@
 import { readFileSync } from 'fs';
 import { env } from './env.js';
-import { resolve } from 'path';
 
 export function getSep2Certificate() {
-    const cert = readFileSync(resolve(env.SEP2_CERT_PATH), 'utf-8');
+    const cert = readFileSync(
+        `${env.CONFIG_DIR}/${env.SEP2_CERT_FILE}`,
+        'utf-8',
+    );
 
     if (!cert) {
         throw new Error('Certificate is not found or is empty');
     }
 
-    const key = readFileSync(resolve(env.SEP2_KEY_PATH), 'utf-8');
+    const key = readFileSync(`${env.CONFIG_DIR}/${env.SEP2_KEY_FILE}`, 'utf-8');
 
     if (!key) {
         throw new Error('Key is not found or is empty');

--- a/src/sep2/helpers/controlScheduler.ts
+++ b/src/sep2/helpers/controlScheduler.ts
@@ -5,7 +5,6 @@ import { ResponseStatus } from '../models/derControlResponse.js';
 import type { DERControlBase } from '../models/derControlBase.js';
 import type {
     DerControlsHelperChangedData,
-    FallbackControl,
     MergedControlsData,
 } from './derControls.js';
 import { DerControlResponseHelper } from './derControlResponse.js';
@@ -17,6 +16,7 @@ import { randomInt } from 'crypto';
 import { addSeconds, isEqual, max } from 'date-fns';
 import { writeControlSchedulerPoints } from '../../helpers/influxdb.js';
 import type { DERControl } from '../models/derControl.js';
+import type { FallbackControl } from './fallbackControl.js';
 
 export type ControlType = Exclude<keyof DERControlBase, 'rampTms'>;
 
@@ -68,11 +68,15 @@ export class ControlSchedulerHelper<ControlKey extends ControlType> {
         });
     }
 
+    updateFallbackControl(fallbackControl: FallbackControl) {
+        this.fallbackControl = fallbackControl;
+    }
+
     updateControlsData({
         activeOrScheduledControls,
         fallbackControl,
     }: DerControlsHelperChangedData) {
-        this.fallbackControl = fallbackControl;
+        this.updateFallbackControl(fallbackControl);
 
         const controlsOfType = filterControlsOfType({
             activeOrScheduledControls,

--- a/src/sep2/helpers/derControls.ts
+++ b/src/sep2/helpers/derControls.ts
@@ -11,6 +11,7 @@ import EventEmitter from 'events';
 import { CurrentStatus } from '../models/eventStatus.js';
 import { DerControlResponseHelper } from './derControlResponse.js';
 import { getDerControlEndDate, sortByProgramPrimacy } from './derControl.js';
+import type { FallbackControl } from './fallbackControl.js';
 
 export type MergedControlsData = {
     fsa: FunctionSetAssignments;
@@ -23,15 +24,6 @@ export type MergedDefaultControlsData = {
     program: DERProgram;
     defaultControl: DefaultDERControl;
 };
-
-export type FallbackControl =
-    | {
-          type: 'default';
-          data: MergedDefaultControlsData;
-      }
-    | {
-          type: 'none';
-      };
 
 export type DerControlsHelperChangedData = {
     activeOrScheduledControls: MergedControlsData[];

--- a/src/sep2/helpers/fallbackControl.ts
+++ b/src/sep2/helpers/fallbackControl.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { env } from '../../helpers/env.js';
+import { writeFile } from 'fs/promises';
+import { readFileSync } from 'fs';
+
+// derived from DefaultDERControl
+export const fallbackControlSchema = z.union([
+    z.object({
+        type: z.literal('default'),
+        data: z.object({
+            defaultControl: z.object({
+                derControlBase: z.object({
+                    opModImpLimW: z
+                        .object({
+                            value: z.number(),
+                            multiplier: z.number(),
+                        })
+                        .optional(),
+                    opModExpLimW: z
+                        .object({
+                            value: z.number(),
+                            multiplier: z.number(),
+                        })
+                        .optional(),
+                    opModGenLimW: z
+                        .object({
+                            value: z.number(),
+                            multiplier: z.number(),
+                        })
+                        .optional(),
+                    opModLoadLimW: z
+                        .object({
+                            value: z.number(),
+                            multiplier: z.number(),
+                        })
+                        .optional(),
+                    opModEnergize: z.boolean().optional(),
+                    opModConnect: z.boolean().optional(),
+                    rampTms: z.number().optional(),
+                }),
+                setGradW: z.number().optional(),
+            }),
+        }),
+    }),
+    z.object({
+        type: z.literal('none'),
+    }),
+]);
+
+export type FallbackControl = z.infer<typeof fallbackControlSchema>;
+
+export function getCachedPath() {
+    return `${env.CONFIG_DIR}/cache_fallbackControl.json`;
+}
+
+export function getCachedFallbackControl(): FallbackControl | null {
+    const cachedFile = (() => {
+        try {
+            return readFileSync(getCachedPath(), 'utf8');
+        } catch {
+            return null;
+        }
+    })();
+
+    if (!cachedFile) {
+        return null;
+    }
+
+    const result = fallbackControlSchema.safeParse(JSON.parse(cachedFile));
+
+    if (!result.success) {
+        return null;
+    }
+
+    return result.data;
+}
+
+export function cacheFallbackControl(data: FallbackControl) {
+    void writeFile(getCachedPath(), JSON.stringify(data));
+}


### PR DESCRIPTION
Gracefully handle scenarios where CSIP-AUS cannot be reached, but the client is restarted so the `DefaultDERControl` is not in memory

Write a derived subset of `DefaultDERControl` to disk and load it initially (before SEP2 is loaded)