### PR TITLE
Build and push multiple (ARM/ARM64) architecture images on Docker Hub

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,12 +43,9 @@ jobs:
         with:
           context: .
           push: true
-          platforms:
-            - linux/amd64
-            - linux/arm64
-            # TODO: find a workaround for https://github.com/docker/build-push-action/issues/1071 without downgrading NodeJS
-            # - linux/arm/v7
-            - linux/arm64/v8
+          # TODO: add linux/arm/v7 once a workaround is found for https://github.com/docker/build-push-action/issues/1071
+          # without downgrading NodeJS
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,7 +43,12 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm64/v8
+          platforms:
+            - linux/amd64
+            - linux/arm64
+            # TODO: find a workaround for https://github.com/docker/build-push-action/issues/1071 without downgrading NodeJS
+            # - linux/arm/v7
+            - linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -45,7 +45,7 @@ jobs:
           push: true
           # TODO: add linux/arm/v7 once a workaround is found for https://github.com/docker/build-push-action/issues/1071
           # without downgrading NodeJS
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
This will make running Open Dynamic Export on smaller/embedded hardware easier, eg. Home Assistant Green/Blue/Yellow/Raspberry Pi + Apple Silicon

Originally I was going with `linux/arm64` only as an addition, but after [some reading](https://uninterrupted.tech/blog/creating-docker-images-that-can-run-on-different-platforms-including-raspberry-pi/) you also need specific arm/arm64 variants for some of the more powerful ARM devices out there. This may need extras added over time, but this change should cover the bulk of the required options.

https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications shows most from a Pi2B upwards will work. Fairly sure the ODROID devices are `arm64/v8`, I'll confirm next week :)

Confirmed on MacOS it wants to use `linux/arm64/v8` with an Apple M1 Pro