### PR TITLE
Infinitely retry event started response

### DIFF
--- a/src/sep2/helpers/derControlResponse.ts
+++ b/src/sep2/helpers/derControlResponse.ts
@@ -91,7 +91,15 @@ export class DerControlResponseHelper {
         try {
             await this.client.post(replyToHref, xml, requestConfig);
         } catch (error) {
-            this.logger.error(error, 'Failed to send DERControl response');
+            this.logger.error(
+                {
+                    error,
+                    mRID,
+                    status,
+                    response,
+                },
+                'Failed to send DERControl response',
+            );
         }
     }
 }

--- a/src/sep2/helpers/derControlResponse.ts
+++ b/src/sep2/helpers/derControlResponse.ts
@@ -7,6 +7,7 @@ import { ResponseRequiredType } from '../models/responseRequired.js';
 import { CappedArrayStack } from '../../helpers/cappedArrayStack.js';
 import deepEqual from 'fast-deep-equal';
 import { ResponseStatus } from '../models/responseStatus.js';
+import { type AxiosRequestConfig } from 'axios';
 
 type HistoryKey = {
     mRID: string;
@@ -33,11 +34,13 @@ export class DerControlResponseHelper {
         replyToHref,
         mRID,
         status,
+        requestConfig,
     }: {
         responseRequired: ResponseRequiredType;
         replyToHref: string | undefined;
         mRID: string;
         status: ResponseStatus;
+        requestConfig?: AxiosRequestConfig;
     }) {
         // if the DERControl does not require any response, we do not respond
         if (responseRequired === (0 as ResponseRequiredType)) {
@@ -86,7 +89,7 @@ export class DerControlResponseHelper {
         const xml = objectToXml(response);
 
         try {
-            await this.client.post(replyToHref, xml);
+            await this.client.post(replyToHref, xml, requestConfig);
         } catch (error) {
             this.logger.error(error, 'Failed to send DERControl response');
         }

--- a/src/sep2/helpers/derControls.test.ts
+++ b/src/sep2/helpers/derControls.test.ts
@@ -35,7 +35,7 @@ beforeAll(() => mockServer.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => mockServer.close());
 
 describe('DerControlsHelper', () => {
-    it('should respond to new DERControls', async () => {
+    it('should respond to new DERControls', () => {
         const derControlsHelper = new DerControlsHelper({
             client: sep2Client,
         });
@@ -46,7 +46,7 @@ describe('DerControlsHelper', () => {
             'respondDerControl',
         );
 
-        await derControlsHelper.updateFsaData([
+        derControlsHelper.updateFsaData([
             {
                 functionSetAssignments: generateMockFunctionSetAssignments({}),
                 derProgramList: [

--- a/src/sep2/helpers/derControls.ts
+++ b/src/sep2/helpers/derControls.ts
@@ -46,7 +46,7 @@ export class DerControlsHelper extends EventEmitter<{
         });
     }
 
-    async updateFsaData(fsaData: FunctionSetAssignmentsListData) {
+    updateFsaData(fsaData: FunctionSetAssignmentsListData) {
         const now = new Date();
 
         // assumptions
@@ -82,7 +82,7 @@ export class DerControlsHelper extends EventEmitter<{
 
         for (const controlData of newControlsData) {
             // always send event received responses for new events
-            await this.derControlResponseHelper.respondDerControl({
+            void this.derControlResponseHelper.respondDerControl({
                 mRID: controlData.control.mRID,
                 replyToHref: controlData.control.replyToHref,
                 responseRequired: controlData.control.responseRequired,
@@ -106,7 +106,7 @@ export class DerControlsHelper extends EventEmitter<{
                 // seconds. This Status.type SHALL NOT be used with “regular” Events, only with specializations of RandomizableEvent.
                 case CurrentStatus.Cancelled:
                 case CurrentStatus.CancelledWithRandomization: {
-                    await this.derControlResponseHelper.respondDerControl({
+                    void this.derControlResponseHelper.respondDerControl({
                         mRID: controlData.control.mRID,
                         replyToHref: controlData.control.replyToHref,
                         responseRequired: controlData.control.responseRequired,

--- a/src/sep2/index.ts
+++ b/src/sep2/index.ts
@@ -164,7 +164,7 @@ export function getSep2Instance({
                 'Received SEP2 function set assignments list',
             );
 
-            void derControlsHelper.updateFsaData(functionSetAssignmentsList);
+            derControlsHelper.updateFsaData(functionSetAssignmentsList);
         },
     );
 


### PR DESCRIPTION
Don't await sending control response because we don't care if it fails

Fixes #75 