### PR TITLE
CSIP recreate MirrorUsagePoint on POST MirrorMeterReading error

### DIFF
--- a/src/sep2/helpers/mirrorUsagePointBase.ts
+++ b/src/sep2/helpers/mirrorUsagePointBase.ts
@@ -327,6 +327,10 @@ export abstract class MirrorUsagePointHelperBase<
                     // "We won’t delete the MUP generally – but when we do a server reset everything in the DB can get reset and so all end points mappings should be considered ephemeral.
                     // (Although no need to check every time – only if you get an error)"
                     // on an error, try re-create the MUP as a precaution
+                    this.logger.debug(
+                        { existingMirrorUsagePoint: this.mirrorUsagePoint },
+                        'Re-creating MirrorUsagePoint due to MirrorMeterReading error',
+                    );
                     await this.initMirrorUsagePoint();
                 }
             }),

--- a/src/sep2/helpers/mirrorUsagePointBase.ts
+++ b/src/sep2/helpers/mirrorUsagePointBase.ts
@@ -129,7 +129,7 @@ export abstract class MirrorUsagePointHelperBase<
 
     protected abstract getReadingMrid(key: MirrorMeterReadingKeys): string;
 
-    protected abstract getReadingDefintions(): Record<
+    protected abstract getReadingDefinitions(): Record<
         MirrorMeterReadingKeys,
         MirrorMeterReadingDefinitions
     >;
@@ -187,7 +187,7 @@ export abstract class MirrorUsagePointHelperBase<
                 reading,
             });
 
-            const mirrorMeterReadingDefinitions = this.getReadingDefintions();
+            const mirrorMeterReadingDefinitions = this.getReadingDefinitions();
 
             const readings = objectEntriesWithType(mirrorMeterReadings)
                 .map(([key, value]): MirrorMeterReading | null => {
@@ -249,7 +249,7 @@ export abstract class MirrorUsagePointHelperBase<
         MirrorMeterReading,
         'Reading'
     >[] {
-        return objectEntriesWithType(this.getReadingDefintions()).map(
+        return objectEntriesWithType(this.getReadingDefinitions()).map(
             ([key, readingDefinition]): Omit<MirrorMeterReading, 'Reading'> => {
                 return {
                     mRID: this.getReadingMrid(key),

--- a/src/sep2/helpers/mirrorUsagePointDer.ts
+++ b/src/sep2/helpers/mirrorUsagePointDer.ts
@@ -528,7 +528,7 @@ export class MirrorUsagePointDerHelper extends MirrorUsagePointHelperBase<
         return this.mirrorMeterReadingMrids[key];
     }
 
-    protected override getReadingDefintions(): Record<
+    protected override getReadingDefinitions(): Record<
         DerMirrorMeterReadingKeys,
         MirrorMeterReadingDefinitions
     > {

--- a/src/sep2/helpers/mirrorUsagePointSite.ts
+++ b/src/sep2/helpers/mirrorUsagePointSite.ts
@@ -528,7 +528,7 @@ export class MirrorUsagePointSiteHelper extends MirrorUsagePointHelperBase<
         return this.mirrorMeterReadingMrids[key];
     }
 
-    protected override getReadingDefintions(): Record<
+    protected override getReadingDefinitions(): Record<
         SiteMirrorMeterReadingKeys,
         MirrorMeterReadingDefinitions
     > {


### PR DESCRIPTION
Recreate MirrorUsagePoint if sending/POST a MirrorMeterReading fails because MirrorUsagePoints might be deleted due to a server reset.

Fixes #78 