### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,7 +1,7 @@
+name: Lint and test
 permissions:
   contents: read
-name: Lint and test
-
+  
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/longzheng/open-dynamic-export/security/code-scanning/7](https://github.com/longzheng/open-dynamic-export/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code, installs dependencies, runs builds, lints, and tests, and does not push changes or create pull requests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file, just below the `name` field and before the `on` field. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
