### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-deployment.yaml
+++ b/.github/workflows/docs-deployment.yaml
@@ -1,7 +1,6 @@
+name: Deploy docs to Cloudflare Pages
 permissions:
   contents: read
-name: Deploy docs to Cloudflare Pages
-
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/longzheng/open-dynamic-export/security/code-scanning/9](https://github.com/longzheng/open-dynamic-export/security/code-scanning/9)

To address the problem, we should explicitly add a `permissions` block to restrict access for the workflow or jobs. The most secure minimal baseline is `permissions: contents: read`. In this workflow, neither the `build` job nor the `deploy` job appears to need special GitHub API permissions—there are no steps that push to the repository, create issues, PRs, or releases. Thus, we can assign only read access to repository contents. This should go at the top level (applies to all jobs), right after the `name` and before `on:` (typically on line 2 or 3). No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
