### PR TITLE
Add fixedDefault limits to CSIP-AUS configuration

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -24,6 +24,27 @@
                   "minLength": 10,
                   "maxLength": 11,
                   "description": "For in-band registration, the NMI of the site"
+                },
+                "fixedDefault": {
+                  "type": "object",
+                  "properties": {
+                    "exportLimitWatts": {
+                      "type": "number",
+                      "minimum": 0,
+                      "description": "The default export limit in watts"
+                    },
+                    "importLimitWatts": {
+                      "type": "number",
+                      "minimum": 0,
+                      "description": "The default import limit in watts"
+                    }
+                  },
+                  "required": [
+                    "exportLimitWatts",
+                    "importLimitWatts"
+                  ],
+                  "additionalProperties": false,
+                  "description": "The default limits in case CSIP-AUS server is unreachable and there is no default control"
                 }
               },
               "required": [

--- a/docs/configuration/setpoints.md
+++ b/docs/configuration/setpoints.md
@@ -36,7 +36,12 @@ To use the CSIP-AUS provided limits as a setpoint, add following property to `co
         "csipAus": {
             "host": "https://sep2-test.energyq.com.au", // (string) required: the CSIP-AUS server host
             "dcapUri": "/api/v2/dcap", // (string) required: the device capability discovery URI
-            "nmi": "1234567890" // (string) optional: for utilities that require in-band registration, the NMI of the site
+            "nmi": "1234567890", // (string) optional: for utilities that require in-band registration, the NMI of the site
+            "fixedDefault": // (object) optional: the default limits in case CSIP-AUS server is unreachable and there is no default control which may be defined in the connection agreement
+            {
+                "exportLimitWatts": 1500, // (number) the default export limit in watts
+                "importLimitWatts": 1500, // (number) the default import limit in watts
+            }
         }
     }
     ...

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -63,6 +63,21 @@ export const configSchema = z.object({
                         .describe(
                             'For in-band registration, the NMI of the site',
                         ),
+                    fixedDefault: z
+                        .object({
+                            exportLimitWatts: z
+                                .number()
+                                .min(0)
+                                .describe('The default export limit in watts'),
+                            importLimitWatts: z
+                                .number()
+                                .min(0)
+                                .describe('The default import limit in watts'),
+                        })
+                        .optional()
+                        .describe(
+                            'The default limits in case CSIP-AUS server is unreachable and there is no default control',
+                        ),
                 })
                 .optional()
                 .describe('If defined, limit by CSIP-AUS server'),

--- a/src/sep2/helpers/controlLimitRamp.test.ts
+++ b/src/sep2/helpers/controlLimitRamp.test.ts
@@ -19,13 +19,22 @@ describe('ControlLimitRampHelper', () => {
         helper = new ControlLimitRampHelper({ rampRateHelper });
     });
 
-    it('should return no value for no target', () => {
-        helper.updateTarget({ type: 'none' });
+    it('should return no value for no target with undefined', () => {
+        helper.updateTarget({ type: 'none', value: undefined });
 
         // cache initial value
         expect(helper.getRampedValue()).toBe(undefined);
 
         expect(helper.getRampedValue()).toBe(undefined);
+    });
+
+    it('should return a value for no target with a value', () => {
+        helper.updateTarget({ type: 'none', value: 5000 });
+
+        // cache initial value
+        expect(helper.getRampedValue()).toBe(5000);
+
+        expect(helper.getRampedValue()).toBe(5000);
     });
 
     it('should return no value for undefined target', () => {

--- a/src/sep2/index.ts
+++ b/src/sep2/index.ts
@@ -87,6 +87,7 @@ export function getSep2Instance({
     const setpoint = new CsipAusSetpoint({
         client: sep2Client,
         rampRateHelper,
+        config,
     });
 
     const derControlsHelper = new DerControlsHelper({

--- a/src/setpoints/csipAus/index.ts
+++ b/src/setpoints/csipAus/index.ts
@@ -11,7 +11,9 @@ import { type DerControlsHelperChangedData } from '../../sep2/helpers/derControl
 import { type SetpointType } from '../setpoint.js';
 import { numberWithPow10 } from '../../helpers/number.js';
 import { writeControlLimit } from '../../helpers/influxdb.js';
+import { type ControlLimitRampTarget } from '../../sep2/helpers/controlLimitRamp.js';
 import { ControlLimitRampHelper } from '../../sep2/helpers/controlLimitRamp.js';
+import { type Config } from '../../helpers/config.js';
 
 export class CsipAusSetpoint implements SetpointType {
     private schedulerByControlType: {
@@ -22,14 +24,18 @@ export class CsipAusSetpoint implements SetpointType {
     private opModImpLimWRampRateHelper: ControlLimitRampHelper;
     private opModLoadLimWRampRateHelper: ControlLimitRampHelper;
     private logger: Logger;
+    private config: Config;
 
     constructor({
         client,
         rampRateHelper,
+        config,
     }: {
         client: SEP2Client;
         rampRateHelper: RampRateHelper;
+        config: Config;
     }) {
+        this.config = config;
         this.logger = pinoLogger.child({ module: 'InverterController' });
 
         this.schedulerByControlType = {
@@ -91,7 +97,7 @@ export class CsipAusSetpoint implements SetpointType {
             this.schedulerByControlType.opModExpLimW.getActiveScheduleDerControlBaseValue();
 
         this.opModExpLimWRampRateHelper.updateTarget(
-            (() => {
+            ((): ControlLimitRampTarget => {
                 switch (opModExpLimW.type) {
                     case 'active':
                     case 'default': {
@@ -107,7 +113,11 @@ export class CsipAusSetpoint implements SetpointType {
                         };
                     }
                     case 'none':
-                        return { type: 'none' };
+                        return {
+                            type: 'none',
+                            value: this.config.setpoints.csipAus?.fixedDefault
+                                ?.exportLimitWatts,
+                        };
                 }
             })(),
         );
@@ -116,7 +126,7 @@ export class CsipAusSetpoint implements SetpointType {
             this.schedulerByControlType.opModGenLimW.getActiveScheduleDerControlBaseValue();
 
         this.opModGenLimWRampRateHelper.updateTarget(
-            (() => {
+            ((): ControlLimitRampTarget => {
                 switch (opModGenLimW.type) {
                     case 'active':
                     case 'default': {
@@ -132,7 +142,7 @@ export class CsipAusSetpoint implements SetpointType {
                         };
                     }
                     case 'none':
-                        return { type: 'none' };
+                        return { type: 'none', value: undefined };
                 }
             })(),
         );
@@ -141,7 +151,7 @@ export class CsipAusSetpoint implements SetpointType {
             this.schedulerByControlType.opModImpLimW.getActiveScheduleDerControlBaseValue();
 
         this.opModImpLimWRampRateHelper.updateTarget(
-            (() => {
+            ((): ControlLimitRampTarget => {
                 switch (opModImpLimW.type) {
                     case 'active':
                     case 'default': {
@@ -157,7 +167,11 @@ export class CsipAusSetpoint implements SetpointType {
                         };
                     }
                     case 'none':
-                        return { type: 'none' };
+                        return {
+                            type: 'none',
+                            value: this.config.setpoints.csipAus?.fixedDefault
+                                ?.importLimitWatts,
+                        };
                 }
             })(),
         );
@@ -166,7 +180,7 @@ export class CsipAusSetpoint implements SetpointType {
             this.schedulerByControlType.opModLoadLimW.getActiveScheduleDerControlBaseValue();
 
         this.opModLoadLimWRampRateHelper.updateTarget(
-            (() => {
+            ((): ControlLimitRampTarget => {
                 switch (opModLoadLimW.type) {
                     case 'active':
                     case 'default': {
@@ -182,7 +196,7 @@ export class CsipAusSetpoint implements SetpointType {
                         };
                     }
                     case 'none':
-                        return { type: 'none' };
+                        return { type: 'none', value: undefined };
                 }
             })(),
         );


### PR DESCRIPTION
This pull request adds support for specifying default import and export limits for CSIP-AUS setpoints when the server is unreachable or no control is defined. It introduces a new `fixedDefault` configuration option, updates the schema and documentation, and refactors the ramp helper logic to use these defaults when appropriate. Additionally, related tests are updated to cover the new logic.
* Added a new `fixedDefault` object to the CSIP-AUS configuration schema, allowing users to specify default `exportLimitWatts` and `importLimitWatts` values. These are used as fallback limits when the CSIP-AUS server is unreachable or no control is defined. (`config.schema.json`, `src/helpers/config.ts`) [[1]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5R27-R47) [[2]](diffhunk://#diff-b133de3707a2586076b97e4901fad59fbc6ea2f4a695c0b7885175855376dd01R66-R80)
* Updated documentation to describe the new `fixedDefault` property and its usage in configuration. (`docs/configuration/setpoints.md`)
