### PR TITLE
Amber: tune polling for NEM 5-minute interval pricing

### DIFF
--- a/src/setpoints/negativeFeedIn/amber/index.test.ts
+++ b/src/setpoints/negativeFeedIn/amber/index.test.ts
@@ -86,4 +86,34 @@ describe('AmberSetpoint', () => {
             opModLoadLimW: undefined,
         } satisfies typeof result);
     });
+
+    it('should hold previous-interval state across the 1s boundary gap', async () => {
+        // Amber returns adjacent intervals as e.g. HH:MM:01 → HH:MM:00,
+        // leaving a 1-second gap at every boundary where strict half-open
+        // matching would return no current interval. Each cached interval's
+        // `end` is extended by 1s so the previous interval covers the boundary
+        // second; verify at 500ms into a gap where the previous interval is
+        // positive-priced (curtail), so the post-fix behaviour is distinct
+        // from the pre-fix "no current interval → no curtail" branch.
+        //
+        // Mock fixture has adjacent feedIn intervals at this boundary:
+        //   2024-09-04T04:00:01Z → 04:30:00Z  perKwh = +2.09587 (curtail)
+        //   2024-09-04T04:30:01Z → 05:00:00Z  perKwh = −0.59540 (no curtail)
+        vi.setSystemTime(new Date('2024-09-04T04:30:00.500Z'));
+
+        // give the polling a chance to finish
+        await vi.advanceTimersToNextTimerAsync();
+
+        const result = amberControlLimit.getInverterControlLimit();
+
+        expect(result).toEqual({
+            source: 'negativeFeedIn',
+            opModConnect: undefined,
+            opModEnergize: undefined,
+            opModExpLimW: 0,
+            opModGenLimW: undefined,
+            opModImpLimW: undefined,
+            opModLoadLimW: undefined,
+        } satisfies typeof result);
+    });
 });

--- a/src/setpoints/negativeFeedIn/amber/index.ts
+++ b/src/setpoints/negativeFeedIn/amber/index.ts
@@ -98,8 +98,15 @@ export class AmberSetpoint implements SetpointType {
                         siteId: this.siteId,
                     },
                     query: {
-                        // cache future prices for 2 hours (at 30 minute intervals)
-                        next: 2 * 2,
+                        // 12 forecast 5-minute intervals = 1 h of headroom
+                        // past the current interval, so a transient Amber
+                        // API outage doesn't drop us back to "no limit".
+                        // Amber's API now returns 5-min intervals to match
+                        // NEM dispatch — the `resolution` query param is
+                        // ignored regardless of value. Forecast accuracy
+                        // degrades further out (see `advancedPrice` spread),
+                        // so 1 h is a deliberate ceiling.
+                        next: 12,
                     },
                 },
                 signal: AbortSignal.any([
@@ -185,8 +192,10 @@ export class AmberSetpoint implements SetpointType {
                     () => {
                         void this.poll();
                     },
-                    // poll every 15 minutes
-                    15 * 60 * 1000,
+                    // poll every 5 minutes — matches the NEM 5-minute dispatch
+                    // interval so each new "current" 5-minute price is picked up
+                    // promptly, instead of falling back to the 30-minute forecast
+                    5 * 60 * 1000,
                 );
             }
         }

--- a/src/setpoints/negativeFeedIn/amber/index.ts
+++ b/src/setpoints/negativeFeedIn/amber/index.ts
@@ -131,7 +131,16 @@ export class AmberSetpoint implements SetpointType {
                 (interval) =>
                     ({
                         start: new Date(interval.startTime),
-                        end: new Date(interval.endTime),
+                        // Amber returns adjacent intervals as e.g.
+                        // start=HH:MM:01 → end=HH:MM:00, leaving a 1-second
+                        // gap at every boundary where neither interval matches
+                        // `now`. Extend the end by 1s so the previous interval
+                        // covers that boundary second; the next interval still
+                        // matches at exactly its start (find() short-circuits
+                        // on the first hit, so no duplicate match).
+                        end: new Date(
+                            new Date(interval.endTime).getTime() + 1000,
+                        ),
                         price: interval.perKwh,
                     }) satisfies Interval,
             );


### PR DESCRIPTION
Amber's API now returns 5-minute `Current` and `Forecast` intervals (matching their 5‑minute billing — see [help article](https://help.amber.com.au/hc/en-us/articles/33265184950669-5-minute-billing)), and the `resolution` query param is silently ignored regardless of value. Three small adjustments:

- Poll every 5 min instead of 15 min, so each new live `Current` interval is picked up promptly instead of falling back to a 30-minute-old forecast value. Rate budget allows it (1/50 of the 50-per-300s window).
- `next: 12` (was `2 * 2`) — 1 hour of forecast headroom so a transient API outage doesn't drop the controller back to "no limit". Larger windows trade against widening `advancedPrice` spreads.
- Extend each cached interval's `end` by 1 s. Amber returns adjacent intervals as `HH:MM:01 → HH:MM:00`, leaving a 1-second gap at every boundary where `getCurrentPrice()` returned `undefined` and curtailment briefly disengaged.

Assumptions verified against a week of production data on a Fronius hybrid setup: the previous 15-min cadence accounted for ~3.8 % of controller decisions disagreeing with the post-hoc settled `feedIn` price (most explained by stale forecasts).

This PR hasn't been soak tested yet though.