### PR TITLE
[codex] Publish CSIP-AUS schedules to MQTT

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -689,6 +689,10 @@
             "topic": {
               "type": "string",
               "description": "The topic to publish limits"
+            },
+            "csipAusControlSchedules": {
+              "type": "string",
+              "description": "The topic to publish CSIP-AUS control schedules. Defaults to \"<topic>/csipAus/schedules\"."
             }
           },
           "required": [
@@ -698,7 +702,7 @@
         }
       },
       "required": [],
-      "description": "Publish active control limits"
+      "description": "Publish active control limits and schedules"
     },
     "battery": {
       "type": "object",

--- a/docs/configuration/publish.md
+++ b/docs/configuration/publish.md
@@ -13,8 +13,8 @@ You can access the API documentation/OpenAPI schema at `http://<host>:3000/docs`
 ## MQTT
 
 Write active limits and CSIP-AUS control schedules to MQTT topics.
-Published MQTT messages use the retain flag, so new subscribers receive the
-latest active limit and control schedule payloads immediately after subscribing.
+Published MQTT messages are not retained. Each update is published even if the
+payload has not changed.
 
 To configure a MQTT output, add the following property to `config.json`
 

--- a/docs/configuration/publish.md
+++ b/docs/configuration/publish.md
@@ -23,14 +23,15 @@ To configure a MQTT output, add the following property to `config.json`
             "host": "mqtt://192.168.1.2", // (string) required: the MQTT broker host
             "username": "user", // (string) optional: the MQTT broker username
             "password": "password", // (string) optional: the MQTT broker password
-            "topic": "limits" // (string) required: the MQTT topic to write
+            "topic": "limits", // (string) required: the MQTT topic to write active limits to
+            "csipAusControlSchedules": "limits/csipAus/schedules" // (string) optional: the MQTT topic to write CSIP-AUS control schedules to
         }
     }
     ...
 }
 ```
 
-The MQTT topic will contain a JSON message that meets the following schema
+The active limits MQTT topic will contain a JSON message that meets the following schema
 
 ```jsonc
 {
@@ -75,5 +76,38 @@ The MQTT topic will contain a JSON message that meets the following schema
         "value": 3000,
         "source": "batteryChargeBuffer",
     },
+}
+```
+
+The CSIP-AUS control schedules topic defaults to `<topic>/csipAus/schedules`.
+It contains a JSON message with the latest scheduled controls, grouped by
+control type:
+
+```jsonc
+{
+    "opModExpLimW": [
+        {
+            "startInclusive": "2026-01-01T00:00:00.000Z",
+            "endExclusive": "2026-01-01T01:00:00.000Z",
+            "effectiveStartInclusive": "2026-01-01T00:00:00.000Z",
+            "effectiveEndExclusive": "2026-01-01T01:00:00.000Z",
+            "randomizeStart": undefined,
+            "randomizeDuration": undefined,
+            "mRID": "control-1",
+            "derControlBase": {
+                "opModExpLimW": {
+                    "value": 5000,
+                    "multiplier": 0,
+                },
+            },
+            "responseRequired": "00",
+            "replyToHref": "/edev/1/rsps",
+        },
+    ],
+    "opModGenLimW": [],
+    "opModImpLimW": [],
+    "opModLoadLimW": [],
+    "opModEnergize": [],
+    "opModConnect": [],
 }
 ```

--- a/docs/configuration/publish.md
+++ b/docs/configuration/publish.md
@@ -12,7 +12,9 @@ You can access the API documentation/OpenAPI schema at `http://<host>:3000/docs`
 
 ## MQTT
 
-Write active limits to a MQTT topic.
+Write active limits and CSIP-AUS control schedules to MQTT topics.
+Published MQTT messages use the retain flag, so new subscribers receive the
+latest active limit and control schedule payloads immediately after subscribing.
 
 To configure a MQTT output, add the following property to `config.json`
 

--- a/src/coordinator/helpers/inverterController.ts
+++ b/src/coordinator/helpers/inverterController.ts
@@ -184,6 +184,12 @@ export class InverterController {
             limit: activeInverterControlLimit,
         });
 
+        if (this.setpoints.csipAus) {
+            this.publish.onCsipAusControlSchedules({
+                schedules: this.setpoints.csipAus.getControlSchedules(),
+            });
+        }
+
         this.controlLimitsCache = {
             controlLimitsBySetpoint,
             activeInverterControlLimit,

--- a/src/coordinator/helpers/publish.test.ts
+++ b/src/coordinator/helpers/publish.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '../../helpers/configSchema.js';
 import type { CsipAusControlSchedules } from '../../setpoints/csipAus/index.js';
+import type { ActiveInverterControlLimit } from './inverterController.js';
 import { Publish } from './publish.js';
 
 const { connectMock, publishMock } = vi.hoisted(() => ({
@@ -42,6 +43,9 @@ describe('Publish', () => {
         expect(publishMock).toHaveBeenCalledWith(
             'limits/csipAus/schedules',
             JSON.stringify(emptySchedules),
+            {
+                retain: true,
+            },
         );
     });
 
@@ -65,6 +69,9 @@ describe('Publish', () => {
         expect(publishMock).toHaveBeenCalledWith(
             'csip/schedules',
             JSON.stringify(emptySchedules),
+            {
+                retain: true,
+            },
         );
     });
 
@@ -89,6 +96,28 @@ describe('Publish', () => {
 
         expect(publishMock).toHaveBeenCalledTimes(1);
     });
+
+    it('does not publish unchanged active inverter control limits repeatedly', () => {
+        const publisher = new Publish({
+            config: {
+                publish: {
+                    mqtt: {
+                        host: 'mqtt://localhost',
+                        topic: 'limits',
+                    },
+                },
+            } satisfies Pick<Config, 'publish'>,
+        });
+
+        publisher.onActiveInverterControlLimit({
+            limit: activeInverterControlLimit,
+        });
+        publisher.onActiveInverterControlLimit({
+            limit: { ...activeInverterControlLimit },
+        });
+
+        expect(publishMock).toHaveBeenCalledTimes(1);
+    });
 });
 
 const emptySchedules = {
@@ -99,3 +128,12 @@ const emptySchedules = {
     opModEnergize: [],
     opModConnect: [],
 } satisfies CsipAusControlSchedules;
+
+const activeInverterControlLimit = {
+    opModEnergize: undefined,
+    opModConnect: undefined,
+    opModGenLimW: undefined,
+    opModExpLimW: { source: 'fixed', value: 5000 },
+    opModImpLimW: undefined,
+    opModLoadLimW: undefined,
+} satisfies ActiveInverterControlLimit;

--- a/src/coordinator/helpers/publish.test.ts
+++ b/src/coordinator/helpers/publish.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Config } from '../../helpers/configSchema.js';
+import type { CsipAusControlSchedules } from '../../setpoints/csipAus/index.js';
+import { Publish } from './publish.js';
+
+const { connectMock, publishMock } = vi.hoisted(() => ({
+    connectMock: vi.fn(),
+    publishMock: vi.fn(),
+}));
+
+vi.mock('mqtt', () => ({
+    default: {
+        connect: connectMock,
+    },
+}));
+
+describe('Publish', () => {
+    beforeEach(() => {
+        connectMock.mockReset();
+        publishMock.mockReset();
+        connectMock.mockReturnValue({
+            publish: publishMock,
+        });
+    });
+
+    it('publishes CSIP-AUS control schedules to the default MQTT topic', () => {
+        const publisher = new Publish({
+            config: {
+                publish: {
+                    mqtt: {
+                        host: 'mqtt://localhost',
+                        topic: 'limits',
+                    },
+                },
+            } satisfies Pick<Config, 'publish'>,
+        });
+
+        publisher.onCsipAusControlSchedules({
+            schedules: emptySchedules,
+        });
+
+        expect(publishMock).toHaveBeenCalledWith(
+            'limits/csipAus/schedules',
+            JSON.stringify(emptySchedules),
+        );
+    });
+
+    it('publishes CSIP-AUS control schedules to the configured MQTT topic', () => {
+        const publisher = new Publish({
+            config: {
+                publish: {
+                    mqtt: {
+                        host: 'mqtt://localhost',
+                        topic: 'limits',
+                        csipAusControlSchedules: 'csip/schedules',
+                    },
+                },
+            } satisfies Pick<Config, 'publish'>,
+        });
+
+        publisher.onCsipAusControlSchedules({
+            schedules: emptySchedules,
+        });
+
+        expect(publishMock).toHaveBeenCalledWith(
+            'csip/schedules',
+            JSON.stringify(emptySchedules),
+        );
+    });
+
+    it('does not publish unchanged CSIP-AUS control schedules repeatedly', () => {
+        const publisher = new Publish({
+            config: {
+                publish: {
+                    mqtt: {
+                        host: 'mqtt://localhost',
+                        topic: 'limits',
+                    },
+                },
+            } satisfies Pick<Config, 'publish'>,
+        });
+
+        publisher.onCsipAusControlSchedules({
+            schedules: emptySchedules,
+        });
+        publisher.onCsipAusControlSchedules({
+            schedules: emptySchedules,
+        });
+
+        expect(publishMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+const emptySchedules = {
+    opModExpLimW: [],
+    opModGenLimW: [],
+    opModImpLimW: [],
+    opModLoadLimW: [],
+    opModEnergize: [],
+    opModConnect: [],
+} satisfies CsipAusControlSchedules;

--- a/src/coordinator/helpers/publish.test.ts
+++ b/src/coordinator/helpers/publish.test.ts
@@ -43,9 +43,6 @@ describe('Publish', () => {
         expect(publishMock).toHaveBeenCalledWith(
             'limits/csipAus/schedules',
             JSON.stringify(emptySchedules),
-            {
-                retain: true,
-            },
         );
     });
 
@@ -69,13 +66,10 @@ describe('Publish', () => {
         expect(publishMock).toHaveBeenCalledWith(
             'csip/schedules',
             JSON.stringify(emptySchedules),
-            {
-                retain: true,
-            },
         );
     });
 
-    it('does not publish unchanged CSIP-AUS control schedules repeatedly', () => {
+    it('publishes unchanged CSIP-AUS control schedules repeatedly', () => {
         const publisher = new Publish({
             config: {
                 publish: {
@@ -94,10 +88,20 @@ describe('Publish', () => {
             schedules: emptySchedules,
         });
 
-        expect(publishMock).toHaveBeenCalledTimes(1);
+        expect(publishMock).toHaveBeenCalledTimes(2);
+        expect(publishMock).toHaveBeenNthCalledWith(
+            1,
+            'limits/csipAus/schedules',
+            JSON.stringify(emptySchedules),
+        );
+        expect(publishMock).toHaveBeenNthCalledWith(
+            2,
+            'limits/csipAus/schedules',
+            JSON.stringify(emptySchedules),
+        );
     });
 
-    it('does not publish unchanged active inverter control limits repeatedly', () => {
+    it('publishes unchanged active inverter control limits repeatedly', () => {
         const publisher = new Publish({
             config: {
                 publish: {
@@ -116,7 +120,17 @@ describe('Publish', () => {
             limit: { ...activeInverterControlLimit },
         });
 
-        expect(publishMock).toHaveBeenCalledTimes(1);
+        expect(publishMock).toHaveBeenCalledTimes(2);
+        expect(publishMock).toHaveBeenNthCalledWith(
+            1,
+            'limits',
+            JSON.stringify(activeInverterControlLimit),
+        );
+        expect(publishMock).toHaveBeenNthCalledWith(
+            2,
+            'limits',
+            JSON.stringify(activeInverterControlLimit),
+        );
     });
 });
 

--- a/src/coordinator/helpers/publish.ts
+++ b/src/coordinator/helpers/publish.ts
@@ -1,9 +1,17 @@
 import mqtt from 'mqtt';
 import type { Config } from '../../helpers/configSchema.js';
+import type { CsipAusControlSchedules } from '../../setpoints/csipAus/index.js';
 import type { ActiveInverterControlLimit } from './inverterController.js';
 
 export class Publish {
-    private mqtt: { client: mqtt.MqttClient; topic: string } | undefined;
+    private mqtt:
+        | {
+              client: mqtt.MqttClient;
+              activeInverterControlLimitTopic: string;
+              csipAusControlSchedules: string;
+              csipAusControlSchedulesPayload: string | null;
+          }
+        | undefined;
 
     constructor({ config }: { config: Pick<Config, 'publish'> }) {
         if (config.publish?.mqtt) {
@@ -12,7 +20,11 @@ export class Publish {
                     username: config.publish.mqtt.username,
                     password: config.publish.mqtt.password,
                 }),
-                topic: config.publish.mqtt.topic,
+                activeInverterControlLimitTopic: config.publish.mqtt.topic,
+                csipAusControlSchedules:
+                    config.publish.mqtt.csipAusControlSchedules ??
+                    `${config.publish.mqtt.topic}/csipAus/schedules`,
+                csipAusControlSchedulesPayload: null,
             };
         }
     }
@@ -23,7 +35,30 @@ export class Publish {
         limit: ActiveInverterControlLimit;
     }) {
         if (this.mqtt) {
-            this.mqtt.client.publish(this.mqtt.topic, JSON.stringify(limit));
+            this.mqtt.client.publish(
+                this.mqtt.activeInverterControlLimitTopic,
+                JSON.stringify(limit),
+            );
+        }
+    }
+
+    onCsipAusControlSchedules({
+        schedules,
+    }: {
+        schedules: CsipAusControlSchedules;
+    }) {
+        if (this.mqtt) {
+            const payload = JSON.stringify(schedules);
+
+            if (payload === this.mqtt.csipAusControlSchedulesPayload) {
+                return;
+            }
+
+            this.mqtt.client.publish(
+                this.mqtt.csipAusControlSchedules,
+                payload,
+            );
+            this.mqtt.csipAusControlSchedulesPayload = payload;
         }
     }
 }

--- a/src/coordinator/helpers/publish.ts
+++ b/src/coordinator/helpers/publish.ts
@@ -8,7 +8,8 @@ export class Publish {
         | {
               client: mqtt.MqttClient;
               activeInverterControlLimitTopic: string;
-              csipAusControlSchedules: string;
+              activeInverterControlLimitPayload: string | null;
+              csipAusControlSchedulesTopic: string;
               csipAusControlSchedulesPayload: string | null;
           }
         | undefined;
@@ -21,7 +22,8 @@ export class Publish {
                     password: config.publish.mqtt.password,
                 }),
                 activeInverterControlLimitTopic: config.publish.mqtt.topic,
-                csipAusControlSchedules:
+                activeInverterControlLimitPayload: null,
+                csipAusControlSchedulesTopic:
                     config.publish.mqtt.csipAusControlSchedules ??
                     `${config.publish.mqtt.topic}/csipAus/schedules`,
                 csipAusControlSchedulesPayload: null,
@@ -35,10 +37,20 @@ export class Publish {
         limit: ActiveInverterControlLimit;
     }) {
         if (this.mqtt) {
+            const payload = JSON.stringify(limit);
+
+            if (payload === this.mqtt.activeInverterControlLimitPayload) {
+                return;
+            }
+
             this.mqtt.client.publish(
                 this.mqtt.activeInverterControlLimitTopic,
-                JSON.stringify(limit),
+                payload,
+                {
+                    retain: true,
+                },
             );
+            this.mqtt.activeInverterControlLimitPayload = payload;
         }
     }
 
@@ -55,8 +67,11 @@ export class Publish {
             }
 
             this.mqtt.client.publish(
-                this.mqtt.csipAusControlSchedules,
+                this.mqtt.csipAusControlSchedulesTopic,
                 payload,
+                {
+                    retain: true,
+                },
             );
             this.mqtt.csipAusControlSchedulesPayload = payload;
         }

--- a/src/coordinator/helpers/publish.ts
+++ b/src/coordinator/helpers/publish.ts
@@ -8,9 +8,7 @@ export class Publish {
         | {
               client: mqtt.MqttClient;
               activeInverterControlLimitTopic: string;
-              activeInverterControlLimitPayload: string | null;
               csipAusControlSchedulesTopic: string;
-              csipAusControlSchedulesPayload: string | null;
           }
         | undefined;
 
@@ -22,11 +20,9 @@ export class Publish {
                     password: config.publish.mqtt.password,
                 }),
                 activeInverterControlLimitTopic: config.publish.mqtt.topic,
-                activeInverterControlLimitPayload: null,
                 csipAusControlSchedulesTopic:
                     config.publish.mqtt.csipAusControlSchedules ??
                     `${config.publish.mqtt.topic}/csipAus/schedules`,
-                csipAusControlSchedulesPayload: null,
             };
         }
     }
@@ -39,18 +35,10 @@ export class Publish {
         if (this.mqtt) {
             const payload = JSON.stringify(limit);
 
-            if (payload === this.mqtt.activeInverterControlLimitPayload) {
-                return;
-            }
-
             this.mqtt.client.publish(
                 this.mqtt.activeInverterControlLimitTopic,
                 payload,
-                {
-                    retain: true,
-                },
             );
-            this.mqtt.activeInverterControlLimitPayload = payload;
         }
     }
 
@@ -62,18 +50,10 @@ export class Publish {
         if (this.mqtt) {
             const payload = JSON.stringify(schedules);
 
-            if (payload === this.mqtt.csipAusControlSchedulesPayload) {
-                return;
-            }
-
             this.mqtt.client.publish(
                 this.mqtt.csipAusControlSchedulesTopic,
                 payload,
-                {
-                    retain: true,
-                },
             );
-            this.mqtt.csipAusControlSchedulesPayload = payload;
         }
     }
 }

--- a/src/helpers/configSchema.ts
+++ b/src/helpers/configSchema.ts
@@ -373,11 +373,17 @@ A longer time will smooth out load changes but may result in overshoot.`,
                             v.string(),
                             v.description('The topic to publish limits'),
                         ),
+                        csipAusControlSchedules: v.pipe(
+                            v.optional(v.string()),
+                            v.description(
+                                'The topic to publish CSIP-AUS control schedules. Defaults to "<topic>/csipAus/schedules".',
+                            ),
+                        ),
                     }),
                 ),
             }),
         ),
-        v.description('Publish active control limits'),
+        v.description('Publish active control limits and schedules'),
     ),
     battery: v.pipe(
         v.optional(

--- a/src/setpoints/csipAus/index.ts
+++ b/src/setpoints/csipAus/index.ts
@@ -16,7 +16,10 @@ import {
     ControlLimitRampHelper,
     type ControlLimitRampTarget,
 } from '../../sep2/helpers/controlLimitRamp.js';
-import { ControlSchedulerHelper } from '../../sep2/helpers/controlScheduler.js';
+import {
+    ControlSchedulerHelper,
+    type RandomizedControlSchedule,
+} from '../../sep2/helpers/controlScheduler.js';
 import {
     DerControlsHelper,
     type DerControlsHelperChangedData,
@@ -38,6 +41,11 @@ import {
 } from '../../sep2/models/endDevice.js';
 import type { EndDeviceList } from '../../sep2/models/endDeviceList.js';
 import type { SetpointType } from '../setpoint.js';
+
+export type CsipAusControlSchedules = Record<
+    SupportedControlTypes,
+    RandomizedControlSchedule[]
+>;
 
 export class CsipAusSetpoint implements SetpointType {
     private schedulerByControlType: {
@@ -279,6 +287,23 @@ export class CsipAusSetpoint implements SetpointType {
 
     getSchedulerByControlType() {
         return this.schedulerByControlType;
+    }
+
+    getControlSchedules(): CsipAusControlSchedules {
+        return {
+            opModExpLimW:
+                this.schedulerByControlType.opModExpLimW.getControlSchedules(),
+            opModGenLimW:
+                this.schedulerByControlType.opModGenLimW.getControlSchedules(),
+            opModImpLimW:
+                this.schedulerByControlType.opModImpLimW.getControlSchedules(),
+            opModLoadLimW:
+                this.schedulerByControlType.opModLoadLimW.getControlSchedules(),
+            opModEnergize:
+                this.schedulerByControlType.opModEnergize.getControlSchedules(),
+            opModConnect:
+                this.schedulerByControlType.opModConnect.getControlSchedules(),
+        };
     }
 
     getStatus() {


### PR DESCRIPTION
## Summary

- Publish CSIP-AUS control schedules to MQTT alongside the existing active-limit output.
- Add `publish.mqtt.csipAusControlSchedules`, defaulting to `<topic>/csipAus/schedules`.
- Expose grouped CSIP-AUS schedules from the setpoint, document the new config, regenerate `config.schema.json`, and add focused publisher tests.

Fixes #133

## Validation

- `git diff --check`
- `node_modules/.bin/tsc -p tsconfig.server.json --noEmit`
- `node_modules/.bin/tsc --ignoreConfig --noEmit --module NodeNext --moduleResolution NodeNext --target ESNext --lib ESNext --types node --esModuleInterop --strict --skipLibCheck --exactOptionalPropertyTypes false src/coordinator/helpers/publish.test.ts`

Not run here: Vitest, `oxlint`, and `oxfmt` cannot start in this Codex shell because their native bindings fail macOS code-signature validation under the bundled Node process.