### PR TITLE
Replace axios with native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,6 @@
         "@tanstack/react-router": "^1.157.14",
         "@tsoa/runtime": "7.0.0-alpha.0",
         "async-mutex": "^0.5.0",
-        "axios": "1.12.2",
-        "axios-retry": "^4.5.0",
         "chart.js": "^4.5.1",
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-plugin-annotation": "^3.1.0",
@@ -74,6 +72,7 @@
         "tailwindcss": "3.4.13",
         "tsoa": "^6.6.0",
         "tsx": "^4.21.0",
+        "undici": "^6.21.3",
         "valibot": "^1.2.0",
         "vite-express": "^0.22.0",
         "xml2js": "^0.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,12 +59,6 @@ importers:
       async-mutex:
         specifier: ^0.5.0
         version: 0.5.0
-      axios:
-        specifier: 1.12.2
-        version: 1.12.2
-      axios-retry:
-        specifier: ^4.5.0
-        version: 4.5.0(axios@1.12.2)
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -149,6 +143,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      undici:
+        specifier: ^6.21.3
+        version: 6.21.3
       valibot:
         specifier: ^1.2.0
         version: 1.3.1(typescript@6.0.2)
@@ -2658,11 +2655,6 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  axios-retry@4.5.0:
-    resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
-    peerDependencies:
-      axios: 0.x || 1.x
-
   axios@1.12.2:
     resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
 
@@ -3651,10 +3643,6 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
-  is-retry-allowed@2.2.0:
-    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
-    engines: {node: '>=10'}
 
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
@@ -4777,6 +4765,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
+    engines: {node: '>=18.17'}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -7783,7 +7775,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  asynckit@0.4.0: {}
+  asynckit@0.4.0:
+    optional: true
 
   atomic-sleep@1.0.0: {}
 
@@ -7796,11 +7789,6 @@ snapshots:
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  axios-retry@4.5.0(axios@1.12.2):
-    dependencies:
-      axios: 1.12.2
-      is-retry-allowed: 2.2.0
-
   axios@1.12.2:
     dependencies:
       follow-redirects: 1.15.11
@@ -7808,6 +7796,7 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+    optional: true
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -8016,6 +8005,7 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+    optional: true
 
   comma-separated-tokens@2.0.3: {}
 
@@ -8309,7 +8299,8 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.3
 
-  delayed-stream@1.0.0: {}
+  delayed-stream@1.0.0:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -8375,6 +8366,7 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -8679,7 +8671,8 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.15.11:
+    optional: true
 
   foreground-child@3.3.1:
     dependencies:
@@ -8693,6 +8686,7 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+    optional: true
 
   forwarded@0.2.0: {}
 
@@ -8797,6 +8791,7 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+    optional: true
 
   hasown@2.0.2:
     dependencies:
@@ -8913,8 +8908,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-promise@4.0.0: {}
-
-  is-retry-allowed@2.2.0: {}
 
   is-what@4.1.16: {}
 
@@ -9537,7 +9530,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@1.1.0:
+    optional: true
 
   pump@3.0.4:
     dependencies:
@@ -10132,6 +10126,8 @@ snapshots:
     optional: true
 
   undici-types@6.21.0: {}
+
+  undici@6.21.3: {}
 
   unist-util-is@6.0.1:
     dependencies:

--- a/src/connections/powerwall2/client.ts
+++ b/src/connections/powerwall2/client.ts
@@ -1,10 +1,13 @@
-import * as https from 'node:https';
+import { Agent } from 'undici';
 import type { Logger } from 'pino';
-import type { AxiosRequestConfig, AxiosInstance } from 'axios';
-import axios, { AxiosError } from 'axios';
 import * as v from 'valibot';
 import { pinoLogger } from '../../helpers/logger.js';
-import { sanitizeAxiosError } from '../../helpers/sanitizeAxiosError.js';
+import {
+    FetchHttpError,
+    fetchWithError,
+    type FetchRequestConfig,
+} from '../../helpers/fetch.js';
+import { sanitizeFetchError } from '../../helpers/sanitizeFetchError.js';
 import {
     meterAggregatesSchema,
     metersSiteSchema,
@@ -13,7 +16,9 @@ import {
 
 export class Powerwall2Client {
     private logger: Logger;
-    private axiosInstance: AxiosInstance;
+    private baseUrl: string;
+    private dispatcher: Agent;
+    private timeoutMilliseconds: number;
     private password: string;
     private token:
         | { type: 'none' }
@@ -32,13 +37,12 @@ export class Powerwall2Client {
         this.password = password;
 
         this.logger = pinoLogger.child({ module: 'Powerwall2' });
-
-        this.axiosInstance = axios.create({
-            baseURL: `https://${ip}`,
-            httpsAgent: new https.Agent({
+        this.baseUrl = `https://${ip}`;
+        this.timeoutMilliseconds = timeoutSeconds * 1000;
+        this.dispatcher = new Agent({
+            connect: {
                 rejectUnauthorized: false,
-            }),
-            timeout: timeoutSeconds * 1000,
+            },
         });
 
         // prefetch token
@@ -71,6 +75,15 @@ export class Powerwall2Client {
         return data;
     }
 
+    private getSignal(signal?: AbortSignal) {
+        return signal
+            ? AbortSignal.any([
+                  AbortSignal.timeout(this.timeoutMilliseconds),
+                  signal,
+              ])
+            : AbortSignal.timeout(this.timeoutMilliseconds);
+    }
+
     private async getToken() {
         switch (this.token.type) {
             case 'cached':
@@ -80,18 +93,24 @@ export class Powerwall2Client {
             case 'none': {
                 const promise = (async () => {
                     try {
-                        const response = await this.axiosInstance.post(
-                            `/api/login/Basic`,
-                            {
+                        const response = await fetchWithError<{
+                            token: string;
+                        }>(`${this.baseUrl}/api/login/Basic`, {
+                            method: 'POST',
+                            dispatcher: this.dispatcher,
+                            signal: this.getSignal(),
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({
                                 username: 'customer',
                                 // the email doesn't seem to actually matter when logging in as customer
                                 email: 'a@a.com',
                                 password: this.password,
-                            },
-                        );
+                            }),
+                        });
 
-                        // oxlint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                        const token = response.data.token as string;
+                        const token = response.data.token;
 
                         this.token = { type: 'cached', token };
 
@@ -100,8 +119,8 @@ export class Powerwall2Client {
                         this.logger.error(
                             {
                                 error:
-                                    error instanceof AxiosError
-                                        ? sanitizeAxiosError(error)
+                                    error instanceof FetchHttpError
+                                        ? sanitizeFetchError(error)
                                         : error,
                             },
                             'Powerwall2 login error',
@@ -122,12 +141,15 @@ export class Powerwall2Client {
 
     private async get(
         url: string,
-        options?: Omit<AxiosRequestConfig<never>, 'headers'>,
+        options?: Omit<FetchRequestConfig<never>, 'headers'>,
         retryCount = 0,
     ): Promise<unknown> {
         try {
-            const response = await this.axiosInstance.get<string>(url, {
+            const response = await fetchWithError(`${this.baseUrl}${url}`, {
                 ...options,
+                dispatcher: this.dispatcher,
+                signal: this.getSignal(options?.signal ?? undefined),
+                method: 'GET',
                 headers: {
                     Cookie: `AuthCookie=${await this.getToken()}`,
                 },
@@ -135,7 +157,7 @@ export class Powerwall2Client {
 
             return response.data;
         } catch (error) {
-            if (error instanceof AxiosError && error.response) {
+            if (error instanceof FetchHttpError && error.response) {
                 this.logger.error(error, 'Powerwall2 API get error');
 
                 // permissions error

--- a/src/helpers/fetch.ts
+++ b/src/helpers/fetch.ts
@@ -1,0 +1,162 @@
+export type RetryOptions = {
+    retries: number;
+    retryCondition?: (error: unknown) => boolean;
+};
+
+export type FetchRequestConfig<TBody = unknown> = Omit<
+    RequestInit,
+    'body' | 'headers'
+> & {
+    body?: TBody;
+    headers?: Record<string, string>;
+    url?: string;
+    params?: Record<string, string | number | boolean | undefined>;
+    retry?: RetryOptions;
+    dispatcher?: unknown;
+};
+
+export type FetchClientResponse<TData = unknown> = {
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    data: TData;
+};
+
+export class FetchHttpError<TData = unknown> extends Error {
+    readonly response?: FetchClientResponse<TData>;
+    readonly config?: FetchRequestConfig;
+    readonly code?: string;
+    readonly status?: number;
+
+    constructor({
+        message,
+        response,
+        config,
+        code,
+    }: {
+        message: string;
+        response?: FetchClientResponse<TData>;
+        config?: FetchRequestConfig;
+        code?: string;
+    }) {
+        super(message);
+        this.name = 'FetchHttpError';
+        this.response = response;
+        this.config = config;
+        this.code = code;
+        this.status = response?.status;
+    }
+}
+
+export function buildUrl(
+    baseUrl: string,
+    link: string,
+    params?: FetchRequestConfig['params'],
+) {
+    const url = new URL(link, baseUrl);
+
+    for (const [key, value] of Object.entries(params ?? {})) {
+        if (value !== undefined) {
+            url.searchParams.set(key, value.toString());
+        }
+    }
+
+    return url.toString();
+}
+
+export function headersToObject(headers: Headers) {
+    return Object.fromEntries(headers.entries());
+}
+
+export function isRetryableFetchError(error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
+        return false;
+    }
+
+    if (error instanceof FetchHttpError) {
+        return (
+            !error.response ||
+            error.response.status === 429 ||
+            error.response.status >= 500
+        );
+    }
+
+    return true;
+}
+
+function getRetryDelayMilliseconds(retryCount: number) {
+    return 2 ** retryCount * 100;
+}
+
+async function parseResponseData(response: Response) {
+    const contentType = response.headers.get('content-type');
+
+    if (contentType?.includes('application/json')) {
+        return response.json();
+    }
+
+    return response.text();
+}
+
+export async function fetchWithError<TData = unknown, TBody = unknown>(
+    url: string,
+    config: FetchRequestConfig<TBody> = {},
+): Promise<FetchClientResponse<TData>> {
+    const { params, retry, body, headers, ...fetchOptions } = config;
+    const requestUrl = buildUrl(url, '', params);
+    const requestConfig = {
+        ...config,
+        params,
+        url: requestUrl,
+    } as FetchRequestConfig;
+    const retries = retry?.retries ?? 0;
+
+    for (let attempt = 0; ; attempt++) {
+        try {
+            const response = await fetch(requestUrl, {
+                ...fetchOptions,
+                headers,
+                body: body as RequestInit['body'],
+            });
+            const data = (await parseResponseData(response)) as TData;
+            const fetchResponse = {
+                status: response.status,
+                statusText: response.statusText,
+                headers: headersToObject(response.headers),
+                data,
+            };
+
+            if (!response.ok) {
+                throw new FetchHttpError({
+                    message: `Request failed with status code ${response.status}`,
+                    response: fetchResponse,
+                    config: requestConfig,
+                });
+            }
+
+            return fetchResponse;
+        } catch (error) {
+            const retryCondition =
+                retry?.retryCondition ?? isRetryableFetchError;
+
+            if (attempt >= retries || !retryCondition(error)) {
+                if (error instanceof FetchHttpError) {
+                    throw error;
+                }
+
+                throw new FetchHttpError({
+                    message:
+                        error instanceof Error
+                            ? error.message
+                            : 'Fetch request failed',
+                    config: requestConfig,
+                    code: error instanceof Error ? error.name : undefined,
+                });
+            }
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, getRetryDelayMilliseconds(attempt + 1));
+            });
+        }
+    }
+}

--- a/src/helpers/sanitizeFetchError.ts
+++ b/src/helpers/sanitizeFetchError.ts
@@ -1,6 +1,6 @@
-import type { AxiosError } from 'axios';
+import type { FetchHttpError } from './fetch.js';
 
-export function sanitizeAxiosError(error: AxiosError) {
+export function sanitizeFetchError(error: FetchHttpError) {
     const { config, response, message, code, status } = error;
 
     return {
@@ -18,11 +18,10 @@ export function sanitizeAxiosError(error: AxiosError) {
         config: config
             ? {
                   headers: config.headers,
-                  baseURL: config.baseURL,
                   method: config.method,
                   url: config.url,
-                  data: config.data as unknown,
-                  'axios-retry': config['axios-retry'],
+                  body: config.body,
+                  retry: config.retry,
               }
             : undefined,
     };

--- a/src/sep2/client.test.ts
+++ b/src/sep2/client.test.ts
@@ -108,7 +108,7 @@ describe('generateMeterReadingMrid', () => {
     });
 });
 
-describe('axios-retry', () => {
+describe('fetch retry', () => {
     let failThreeRequestCount = 0;
 
     beforeEach(() => {

--- a/src/sep2/client.ts
+++ b/src/sep2/client.ts
@@ -1,10 +1,13 @@
-import * as https from 'node:https';
 import { createHash } from 'node:crypto';
-import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
-import axios from 'axios';
+import { Agent } from 'undici';
 import { parseStringPromise } from 'xml2js';
-import axiosRetry, { exponentialDelay } from 'axios-retry';
 import { numberToHex } from '../helpers/number.js';
+import {
+    buildUrl,
+    fetchWithError,
+    type FetchClientResponse,
+    type FetchRequestConfig,
+} from '../helpers/fetch.js';
 import {
     getCertificateFingerprint,
     getCertificateLfdi,
@@ -14,12 +17,15 @@ import type { RoleFlagsType } from './models/roleFlagsType.js';
 
 const USER_AGENT = 'open-dynamic-export';
 
+export type SEP2RequestConfig<TBody = unknown> = FetchRequestConfig<TBody>;
+export type SEP2Response<TData = unknown> = FetchClientResponse<TData>;
+
 export class SEP2Client {
     private readonly host: string;
     public readonly pen: string;
     public readonly lfdi: string;
     public readonly sfdi: string;
-    private readonly axiosInstance: AxiosInstance;
+    private readonly dispatcher: Agent;
 
     constructor({
         host,
@@ -40,42 +46,48 @@ export class SEP2Client {
         this.lfdi = getCertificateLfdi(certificateFingerprint);
         this.sfdi = getCertificateSfdi(certificateFingerprint);
 
-        const axiosClient = axios.create({
-            baseURL: this.host,
-            headers: {
-                'User-Agent': USER_AGENT,
-                Accept: 'application/sep+xml',
-                'Content-Type': 'application/sep+xml',
-            },
-            httpsAgent: new https.Agent({
+        this.dispatcher = new Agent({
+            connect: {
                 cert,
                 key,
                 // the device certificate will have the full chain
                 ca: cert,
                 // ignore certificate errors
                 rejectUnauthorized: false,
-                // the IEEE2023.5 certifiate does not have the host name as the certificate altnames
+                // the IEEE2023.5 certificate does not have the host name as the certificate altnames
                 // bypass the server identity check
                 checkServerIdentity: () => undefined,
-            }),
+            },
         });
+    }
 
-        // exponential backoff retry
-        axiosRetry(axiosClient, {
-            retries: 5,
-            retryDelay: (retryCount, error) =>
-                exponentialDelay(retryCount, error, 100),
-        });
-
-        this.axiosInstance = axiosClient;
+    private getDefaultConfig<TBody>(): SEP2RequestConfig<TBody> {
+        return {
+            dispatcher: this.dispatcher,
+            headers: {
+                'User-Agent': USER_AGENT,
+                Accept: 'application/sep+xml',
+                'Content-Type': 'application/sep+xml',
+            },
+        };
     }
 
     async get(
         link: string,
-        options?: AxiosRequestConfig<never>,
+        options?: SEP2RequestConfig<never>,
     ): Promise<unknown> {
-        const url = `${this.host}${link}`;
-        const response = await this.axiosInstance.get<string>(url, options);
+        const url = buildUrl(this.host, link);
+        const response = await fetchWithError<string, never>(url, {
+            ...this.getDefaultConfig(),
+            ...options,
+            headers: {
+                ...this.getDefaultConfig().headers,
+                ...options?.headers,
+            },
+            method: 'GET',
+            // exponential backoff retry
+            retry: options?.retry ?? { retries: 5 },
+        });
 
         return await parseStringPromise(response.data);
     }
@@ -83,22 +95,37 @@ export class SEP2Client {
     async post<T>(
         link: string,
         data: T,
-        options?: AxiosRequestConfig<T>,
-    ): Promise<AxiosResponse> {
-        const url = `${this.host}${link}`;
-        const response = await this.axiosInstance.post(url, data, options);
-        return response;
+        options?: SEP2RequestConfig<T>,
+    ): Promise<SEP2Response> {
+        const url = buildUrl(this.host, link);
+        return await fetchWithError(url, {
+            ...this.getDefaultConfig<T>(),
+            ...options,
+            headers: {
+                ...this.getDefaultConfig().headers,
+                ...options?.headers,
+            },
+            method: 'POST',
+            body: data,
+        });
     }
 
     async put<T>(
         link: string,
         data: T,
-        options?: AxiosRequestConfig<T>,
-    ): Promise<AxiosResponse> {
-        const url = `${this.host}${link}`;
-        const response = await this.axiosInstance.put(url, data, options);
-
-        return response;
+        options?: SEP2RequestConfig<T>,
+    ): Promise<SEP2Response> {
+        const url = buildUrl(this.host, link);
+        return await fetchWithError(url, {
+            ...this.getDefaultConfig<T>(),
+            ...options,
+            headers: {
+                ...this.getDefaultConfig().headers,
+                ...options?.headers,
+            },
+            method: 'PUT',
+            body: data,
+        });
     }
 
     // From the SEP2 Client Handbook

--- a/src/sep2/helpers/controlScheduler.ts
+++ b/src/sep2/helpers/controlScheduler.ts
@@ -215,7 +215,7 @@ export class ControlSchedulerHelper<ControlKey extends ControlType> {
                 status: ResponseStatus.EventStarted,
                 requestConfig: {
                     // recommendation from Energex to retry infinitely until the event ends
-                    'axios-retry': {
+                    retry: {
                         retries: Infinity,
                         retryCondition: () => {
                             return (

--- a/src/sep2/helpers/der.ts
+++ b/src/sep2/helpers/der.ts
@@ -1,6 +1,6 @@
 import type { Logger } from 'pino';
 import deepEqual from 'fast-deep-equal';
-import { AxiosError } from 'axios';
+import { FetchHttpError } from '../../helpers/fetch.js';
 import { defaultPollPushRates, type SEP2Client } from '../client.js';
 import type { DER } from '../models/der.js';
 import type { DERCapability } from '../models/derCapability.js';
@@ -17,7 +17,7 @@ import { DERControlType } from '../models/derControlType.js';
 import { convertNumberToBaseAndPow10Exponent } from '../../helpers/number.js';
 import { DOEControlType } from '../models/doeModesSupportedType.js';
 import type { DerSample } from '../../coordinator/helpers/derSample.js';
-import { sanitizeAxiosError } from '../../helpers/sanitizeAxiosError.js';
+import { sanitizeFetchError } from '../../helpers/sanitizeFetchError.js';
 import type { RampRateHelper } from './rampRate.js';
 import { objectToXml } from './xml.js';
 
@@ -129,7 +129,9 @@ export class DerHelper {
             await this.putDerStatus({ derStatus: this.lastSentDerStatus });
         } catch (error) {
             this.logger.error(
-                error instanceof AxiosError ? sanitizeAxiosError(error) : error,
+                error instanceof FetchHttpError
+                    ? sanitizeFetchError(error)
+                    : error,
                 'Error updating DER status during scheduled poll',
             );
         }
@@ -179,7 +181,9 @@ export class DerHelper {
             await this.client.put(this.config.der.derCapabilityLink.href, xml);
         } catch (error) {
             this.logger.error(
-                error instanceof AxiosError ? sanitizeAxiosError(error) : error,
+                error instanceof FetchHttpError
+                    ? sanitizeFetchError(error)
+                    : error,
                 'Error updating DER capability',
             );
 
@@ -212,7 +216,9 @@ export class DerHelper {
             await this.client.put(this.config.der.derSettingsLink.href, xml);
         } catch (error) {
             this.logger.error(
-                error instanceof AxiosError ? sanitizeAxiosError(error) : error,
+                error instanceof FetchHttpError
+                    ? sanitizeFetchError(error)
+                    : error,
                 'Error updating DER settings',
             );
 
@@ -241,7 +247,9 @@ export class DerHelper {
             await this.client.put(this.config.der.derStatusLink.href, xml);
         } catch (error) {
             this.logger.error(
-                error instanceof AxiosError ? sanitizeAxiosError(error) : error,
+                error instanceof FetchHttpError
+                    ? sanitizeFetchError(error)
+                    : error,
                 'Error updating DER status',
             );
 

--- a/src/sep2/helpers/derControlResponse.ts
+++ b/src/sep2/helpers/derControlResponse.ts
@@ -1,13 +1,16 @@
 import type { Logger } from 'pino';
 import deepEqual from 'fast-deep-equal';
-import { AxiosError, type AxiosRequestConfig } from 'axios';
+import {
+    FetchHttpError,
+    type FetchRequestConfig,
+} from '../../helpers/fetch.js';
 import type { SEP2Client } from '../client.js';
 import { pinoLogger } from '../../helpers/logger.js';
 import { generateDerControlResponse } from '../models/derControlResponse.js';
 import { ResponseRequiredType } from '../models/responseRequired.js';
 import { CappedArrayStack } from '../../helpers/cappedArrayStack.js';
 import { ResponseStatus } from '../models/responseStatus.js';
-import { sanitizeAxiosError } from '../../helpers/sanitizeAxiosError.js';
+import { sanitizeFetchError } from '../../helpers/sanitizeFetchError.js';
 import { objectToXml } from './xml.js';
 
 type HistoryKey = {
@@ -58,7 +61,7 @@ export class DerControlResponseHelper {
         replyToHref: string | undefined;
         mRID: string;
         status: ResponseStatus;
-        requestConfig?: AxiosRequestConfig;
+        requestConfig?: FetchRequestConfig;
     }) {
         // if the DERControl does not require any response, we do not respond
         if (responseRequired === (0 as ResponseRequiredType)) {
@@ -112,8 +115,8 @@ export class DerControlResponseHelper {
             this.logger.error(
                 {
                     error:
-                        error instanceof AxiosError
-                            ? sanitizeAxiosError(error)
+                        error instanceof FetchHttpError
+                            ? sanitizeFetchError(error)
                             : error,
                     mRID,
                     status,

--- a/src/sep2/helpers/derProgramList.ts
+++ b/src/sep2/helpers/derProgramList.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events';
 import * as v from 'valibot';
 import type { Logger } from 'pino';
-import { AxiosError } from 'axios';
+import { FetchHttpError } from '../../helpers/fetch.js';
 import type { SEP2Client } from '../client.js';
 import { defaultPollPushRates } from '../client.js';
 import {
@@ -16,7 +16,7 @@ import {
 import { parseDerControlListXml } from '../models/derControlList.js';
 import { derControlSchema } from '../models/derControl.js';
 import { pinoLogger } from '../../helpers/logger.js';
-import { sanitizeAxiosError } from '../../helpers/sanitizeAxiosError.js';
+import { sanitizeFetchError } from '../../helpers/sanitizeFetchError.js';
 import { getListAll } from './pagination.js';
 import { PollableResource } from './pollableResource.js';
 
@@ -121,8 +121,8 @@ export class DerProgramListHelper extends EventEmitter<{
                             this.emit('data', result);
                         } catch (error) {
                             this.logger.error(
-                                error instanceof AxiosError
-                                    ? sanitizeAxiosError(error)
+                                error instanceof FetchHttpError
+                                    ? sanitizeFetchError(error)
                                     : error,
                                 'Error processing DerProgramList data',
                             );

--- a/src/sep2/helpers/mirrorUsagePointBase.ts
+++ b/src/sep2/helpers/mirrorUsagePointBase.ts
@@ -1,6 +1,5 @@
 import type { Logger } from 'pino';
-import { isNetworkError, isRetryableError } from 'axios-retry';
-import { AxiosError } from 'axios';
+import { FetchHttpError } from '../../helpers/fetch.js';
 import {
     getMillisecondsToNextUtcIntervalTick,
     getUtcTickStart,
@@ -22,7 +21,7 @@ import type { SampleBase } from '../../coordinator/helpers/sampleBase.js';
 import { objectEntriesWithType } from '../../helpers/object.js';
 import { CappedArrayStack } from '../../helpers/cappedArrayStack.js';
 import { UsagePointBaseStatus } from '../models/usagePointBaseStatus.js';
-import { sanitizeAxiosError } from '../../helpers/sanitizeAxiosError.js';
+import { sanitizeFetchError } from '../../helpers/sanitizeFetchError.js';
 import { objectToXml } from './xml.js';
 
 const MIN_INT16 = -32768;
@@ -186,7 +185,9 @@ export abstract class MirrorUsagePointHelperBase<
             this.queueMirrorMeterReadingPost();
         } catch (error) {
             this.logger.debug(
-                error instanceof AxiosError ? sanitizeAxiosError(error) : error,
+                error instanceof FetchHttpError
+                    ? sanitizeFetchError(error)
+                    : error,
                 'Failed to create MirrorUsagePoint',
             );
             this.state = { type: 'none' };
@@ -419,8 +420,8 @@ export abstract class MirrorUsagePointHelperBase<
                 successCount++;
             } catch (error) {
                 this.logger.debug(
-                    error instanceof AxiosError
-                        ? sanitizeAxiosError(error)
+                    error instanceof FetchHttpError
+                        ? sanitizeFetchError(error)
                         : error,
                     'Failed to post MirrorMeterReading',
                 );
@@ -467,12 +468,9 @@ export abstract class MirrorUsagePointHelperBase<
             this.state.mirrorUsagePoint.href,
             xml,
             {
-                'axios-retry': {
-                    // by default axios-retry will not retry POST errors
+                retry: {
                     // we know these calls are idempotent so we can retry them
-                    retryCondition: (error) => {
-                        return isNetworkError(error) || isRetryableError(error);
-                    },
+                    retries: 5,
                 },
                 signal: this.abortController.signal,
             },

--- a/src/sep2/helpers/pagination.ts
+++ b/src/sep2/helpers/pagination.ts
@@ -1,11 +1,10 @@
-import type { AxiosRequestConfig } from 'axios';
-import type { SEP2Client } from '../client.js';
+import type { SEP2Client, SEP2RequestConfig } from '../client.js';
 import type { List } from '../models/list.js';
 
 export interface PaginationOptions<T extends List> {
     client: SEP2Client;
     url: string;
-    options?: Omit<AxiosRequestConfig<never>, 'params'>;
+    options?: Omit<SEP2RequestConfig<never>, 'params'>;
     parseXml: (xml: unknown) => T;
     getItems: (result: T) => unknown[];
     limit?: number;

--- a/src/sep2/helpers/pollableResource.ts
+++ b/src/sep2/helpers/pollableResource.ts
@@ -1,9 +1,9 @@
 import EventEmitter from 'events';
-import { AxiosError } from 'axios';
+import { FetchHttpError } from '../../helpers/fetch.js';
 import type { PollRate } from '../models/pollRate.js';
 import type { SEP2Client } from '../client.js';
 import { pinoLogger } from '../../helpers/logger.js';
-import { sanitizeAxiosError } from '../../helpers/sanitizeAxiosError.js';
+import { sanitizeFetchError } from '../../helpers/sanitizeFetchError.js';
 
 export abstract class PollableResource<
     ResponseType extends { pollRate: PollRate },
@@ -61,8 +61,8 @@ export abstract class PollableResource<
                 }
 
                 pinoLogger.error(
-                    error instanceof AxiosError
-                        ? sanitizeAxiosError(error)
+                    error instanceof FetchHttpError
+                        ? sanitizeFetchError(error)
                         : error,
                     'Failed to poll resource',
                 );

--- a/src/setpoints/negativeFeedIn/amber/index.ts
+++ b/src/setpoints/negativeFeedIn/amber/index.ts
@@ -1,7 +1,7 @@
 import type { Client } from 'openapi-fetch';
 import createClient from 'openapi-fetch';
 import type { Logger } from 'pino';
-import { AxiosError } from 'axios';
+import { FetchHttpError } from '../../../helpers/fetch.js';
 import type { SetpointType } from '../../setpoint.js';
 import type { InverterControlLimit } from '../../../coordinator/helpers/inverterController.js';
 import { pinoLogger } from '../../../helpers/logger.js';
@@ -9,7 +9,7 @@ import {
     writeAmberPrice,
     writeControlLimit,
 } from '../../../helpers/influxdb.js';
-import { sanitizeAxiosError } from '../../../helpers/sanitizeAxiosError.js';
+import { sanitizeFetchError } from '../../../helpers/sanitizeFetchError.js';
 import type { paths } from './api.js';
 
 type Interval = {
@@ -192,7 +192,9 @@ export class AmberSetpoint implements SetpointType {
             await this.getSiteFeedInPrices();
         } catch (error) {
             this.logger.error(
-                error instanceof AxiosError ? sanitizeAxiosError(error) : error,
+                error instanceof FetchHttpError
+                    ? sanitizeFetchError(error)
+                    : error,
                 'Failed to poll Amber API',
             );
         } finally {


### PR DESCRIPTION
### Motivation
- Remove runtime dependency on `axios`/`axios-retry` and use native `fetch` with a shared helper to unify request/response/error shapes and retry behavior.
- Use `undici` `Agent` for TLS client dispatch so SEP2 / device clients can continue to use client certificates and custom TLS options.

### Description
- Removed `axios` and `axios-retry` usages and added `undici` to `package.json` and lockfile, and created a shared fetch helper at `src/helpers/fetch.ts` that provides `fetchWithError`, `FetchHttpError`, URL building, header normalization, and retry semantics.
- Replaced the SEP2 client implementation in `src/sep2/client.ts` to call `fetchWithError` with a `undici` `Agent` dispatcher, preserving SEP2 headers, XML parsing, and default retry behavior.
- Replaced the Powerwall v2 client in `src/connections/powerwall2/client.ts` to use `fetchWithError` (token fetch, cached token handling, cookie header, timeout via `AbortSignal`, and retry-on-401 refresh preserved).
- Replaced `sanitizeAxiosError` with `sanitizeFetchError` and updated SEP2 helper modules (`der`, `derControlResponse`, `derProgramList`, `mirrorUsagePointBase`, `pollableResource`, `pagination`, Amber setpoint, and others) to use the new error type and the `retry` option shape instead of `'axios-retry'`.

### Testing
- Ran `pnpm run lint` which executed route generation, linter and formatter checks and succeeded.
- Ran `pnpm run build` which generated routes, ran `tsc` and built the client bundle and succeeded.
- Initialized example env and ran tests with `cp .env.example .env && pnpm test` and all test suites passed (`80 files`, `354 tests` all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bd9572e788327b0dcf444217ff51b)